### PR TITLE
fix(keap): share contact field schema across mapping refresh

### DIFF
--- a/frontend/src/components/AllIntegrations/Keap/Keap.jsx
+++ b/frontend/src/components/AllIntegrations/Keap/Keap.jsx
@@ -18,59 +18,7 @@ function Keap({ formFields, setFlow, flow, allIntegURL }) {
   const [isLoading, setIsLoading] = useState(false)
   const [step, setstep] = useState(1)
   const [snack, setSnackbar] = useState({ show: false })
-  const contactFields = [
-    { key: 'given_name', label: __('First Name', 'bit-integrations'), required: true },
-    { key: 'middle_name', label: __('Middle Name', 'bit-integrations'), required: false },
-    { key: 'family_name', label: __('Last Name', 'bit-integrations'), required: false },
-    { key: 'job_title', label: __('Job Title', 'bit-integrations'), required: false },
-    { key: 'email_addresses', label: __('Email Addresses', 'bit-integrations'), required: true },
-    { key: 'phone_numbers', label: __('Phone Numbers', 'bit-integrations'), required: false },
-    {
-      key: 'billing_country_code',
-      label: __('Billing Country Code', 'bit-integrations'),
-      required: false
-    },
-    { key: 'billing_locality', label: __('Billing Country', 'bit-integrations'), required: false },
-    {
-      key: 'billing_first_address_street',
-      label: __('Billing Address Street (Line 1)', 'bit-integrations'),
-      required: false
-    },
-    {
-      key: 'billing_second_address_street',
-      label: __('Billing Address Street (Line 2)', 'bit-integrations'),
-      required: false
-    },
-    { key: 'billing_zip_code', label: __('Billing Zip Code', 'bit-integrations'), required: false },
-    {
-      key: 'shipping_country_code',
-      label: __('Shipping Country Code', 'bit-integrations'),
-      required: false
-    },
-    {
-      key: 'shipping_locality',
-      label: __('Shipping Country', 'bit-integrations'),
-      required: false
-    },
-    {
-      key: 'shipping_first_address_street',
-      label: __('Shipping Address Street (Line 1)', 'bit-integrations'),
-      required: false
-    },
-    {
-      key: 'shipping_second_address_street',
-      label: __('Shipping Address Street (Line 2)', 'bit-integrations'),
-      required: false
-    },
-    {
-      key: 'shipping_zip_code',
-      label: __('Shipping Zip Code', 'bit-integrations'),
-      required: false
-    },
-    { key: 'anniversary', label: __('Anniversary', 'bit-integrations'), required: false },
-    { key: 'birthday', label: __('Birthday', 'bit-integrations'), required: false },
-    { key: 'fax_numbers', label: __('Fax Numbers', 'bit-integrations'), required: false }
-  ]
+
   const [keapConf, setKeapConf] = useState({
     name: 'Keap',
     type: 'Keap',
@@ -165,3 +113,58 @@ function Keap({ formFields, setFlow, flow, allIntegURL }) {
 }
 
 export default Keap
+
+
+export const contactFields = [
+  { key: 'given_name', label: __('First Name', 'bit-integrations'), required: true },
+  { key: 'middle_name', label: __('Middle Name', 'bit-integrations'), required: false },
+  { key: 'family_name', label: __('Last Name', 'bit-integrations'), required: false },
+  { key: 'job_title', label: __('Job Title', 'bit-integrations'), required: false },
+  { key: 'email_addresses', label: __('Email Addresses', 'bit-integrations'), required: true },
+  { key: 'phone_numbers', label: __('Phone Numbers', 'bit-integrations'), required: false },
+  {
+    key: 'billing_country_code',
+    label: __('Billing Country Code', 'bit-integrations'),
+    required: false
+  },
+  { key: 'billing_locality', label: __('Billing Country', 'bit-integrations'), required: false },
+  {
+    key: 'billing_first_address_street',
+    label: __('Billing Address Street (Line 1)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'billing_second_address_street',
+    label: __('Billing Address Street (Line 2)', 'bit-integrations'),
+    required: false
+  },
+  { key: 'billing_zip_code', label: __('Billing Zip Code', 'bit-integrations'), required: false },
+  {
+    key: 'shipping_country_code',
+    label: __('Shipping Country Code', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_locality',
+    label: __('Shipping Country', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_first_address_street',
+    label: __('Shipping Address Street (Line 1)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_second_address_street',
+    label: __('Shipping Address Street (Line 2)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_zip_code',
+    label: __('Shipping Zip Code', 'bit-integrations'),
+    required: false
+  },
+  { key: 'anniversary', label: __('Anniversary', 'bit-integrations'), required: false },
+  { key: 'birthday', label: __('Birthday', 'bit-integrations'), required: false },
+  { key: 'fax_numbers', label: __('Fax Numbers', 'bit-integrations'), required: false }
+]

--- a/frontend/src/components/AllIntegrations/Keap/Keap.jsx
+++ b/frontend/src/components/AllIntegrations/Keap/Keap.jsx
@@ -11,6 +11,7 @@ import IntegrationStepThree from '../IntegrationHelpers/IntegrationStepThree'
 import { handleInput, checkMappedFields } from './KeapCommonFunc'
 import KeapIntegLayout from './KeapIntegLayout'
 import { saveActionConf } from '../IntegrationHelpers/IntegrationHelpers'
+import { contactFields } from './staticData'
 
 function Keap({ formFields, setFlow, flow, allIntegURL }) {
   const navigate = useNavigate()
@@ -26,7 +27,7 @@ function Keap({ formFields, setFlow, flow, allIntegURL }) {
     clientSecret: '',
     keapId: '',
     field_map: [{ formField: '', keapField: '' }],
-    contactFields,
+    contactFields: contactFields,
     customFields: [],
     actions: {}
   })
@@ -113,58 +114,3 @@ function Keap({ formFields, setFlow, flow, allIntegURL }) {
 }
 
 export default Keap
-
-
-export const contactFields = [
-  { key: 'given_name', label: __('First Name', 'bit-integrations'), required: true },
-  { key: 'middle_name', label: __('Middle Name', 'bit-integrations'), required: false },
-  { key: 'family_name', label: __('Last Name', 'bit-integrations'), required: false },
-  { key: 'job_title', label: __('Job Title', 'bit-integrations'), required: false },
-  { key: 'email_addresses', label: __('Email Addresses', 'bit-integrations'), required: true },
-  { key: 'phone_numbers', label: __('Phone Numbers', 'bit-integrations'), required: false },
-  {
-    key: 'billing_country_code',
-    label: __('Billing Country Code', 'bit-integrations'),
-    required: false
-  },
-  { key: 'billing_locality', label: __('Billing Country', 'bit-integrations'), required: false },
-  {
-    key: 'billing_first_address_street',
-    label: __('Billing Address Street (Line 1)', 'bit-integrations'),
-    required: false
-  },
-  {
-    key: 'billing_second_address_street',
-    label: __('Billing Address Street (Line 2)', 'bit-integrations'),
-    required: false
-  },
-  { key: 'billing_zip_code', label: __('Billing Zip Code', 'bit-integrations'), required: false },
-  {
-    key: 'shipping_country_code',
-    label: __('Shipping Country Code', 'bit-integrations'),
-    required: false
-  },
-  {
-    key: 'shipping_locality',
-    label: __('Shipping Country', 'bit-integrations'),
-    required: false
-  },
-  {
-    key: 'shipping_first_address_street',
-    label: __('Shipping Address Street (Line 1)', 'bit-integrations'),
-    required: false
-  },
-  {
-    key: 'shipping_second_address_street',
-    label: __('Shipping Address Street (Line 2)', 'bit-integrations'),
-    required: false
-  },
-  {
-    key: 'shipping_zip_code',
-    label: __('Shipping Zip Code', 'bit-integrations'),
-    required: false
-  },
-  { key: 'anniversary', label: __('Anniversary', 'bit-integrations'), required: false },
-  { key: 'birthday', label: __('Birthday', 'bit-integrations'), required: false },
-  { key: 'fax_numbers', label: __('Fax Numbers', 'bit-integrations'), required: false }
-]

--- a/frontend/src/components/AllIntegrations/Keap/KeapAuthorization.jsx
+++ b/frontend/src/components/AllIntegrations/Keap/KeapAuthorization.jsx
@@ -38,7 +38,7 @@ export default function KeapAuthorization({
       document.getElementById('btcd-settings-wrp').scrollTop = 0
     }, 300)
 
-    refreshCustomFields(keapConf, setKeapConf, setIsLoading, setSnackbar)
+    refreshCustomFields(formID, keapConf, setKeapConf, setIsLoading, setSnackbar)
     setstep(2)
   }
   return (

--- a/frontend/src/components/AllIntegrations/Keap/KeapCommonFunc.js
+++ b/frontend/src/components/AllIntegrations/Keap/KeapCommonFunc.js
@@ -1,5 +1,6 @@
 import { __, sprintf } from '../../../Utils/i18nwrap'
 import bitsFetch from '../../../Utils/bitsFetch'
+import { contactFields } from './Keap'
 
 export const handleInput = (
   e,
@@ -196,6 +197,7 @@ export const refreshCustomFields = (id, confTmp, setConf, setIsLoading, setSnack
     if (result && result.success) {
       const newConf = { ...confTmp }
       if (result.data) {
+        newConf.contactFields = contactFields
         newConf.customFields = result.data
       }
       newConf.field_map = generateMappedField(newConf)

--- a/frontend/src/components/AllIntegrations/Keap/KeapCommonFunc.js
+++ b/frontend/src/components/AllIntegrations/Keap/KeapCommonFunc.js
@@ -1,6 +1,6 @@
 import { __, sprintf } from '../../../Utils/i18nwrap'
 import bitsFetch from '../../../Utils/bitsFetch'
-import { contactFields } from './Keap'
+import { contactFields } from './staticData'
 
 export const handleInput = (
   e,

--- a/frontend/src/components/AllIntegrations/Keap/staticData.js
+++ b/frontend/src/components/AllIntegrations/Keap/staticData.js
@@ -1,0 +1,55 @@
+import { __ } from "../../../Utils/i18nwrap";
+
+export const contactFields = [
+  { key: 'given_name', label: __('First Name', 'bit-integrations'), required: true },
+  { key: 'middle_name', label: __('Middle Name', 'bit-integrations'), required: false },
+  { key: 'family_name', label: __('Last Name', 'bit-integrations'), required: false },
+  { key: 'job_title', label: __('Job Title', 'bit-integrations'), required: false },
+  { key: 'email_addresses', label: __('Email Addresses', 'bit-integrations'), required: true },
+  { key: 'phone_numbers', label: __('Phone Numbers', 'bit-integrations'), required: false },
+  {
+    key: 'billing_country_code',
+    label: __('Billing Country Code', 'bit-integrations'),
+    required: false
+  },
+  { key: 'billing_locality', label: __('Billing Country', 'bit-integrations'), required: false },
+  {
+    key: 'billing_first_address_street',
+    label: __('Billing Address Street (Line 1)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'billing_second_address_street',
+    label: __('Billing Address Street (Line 2)', 'bit-integrations'),
+    required: false
+  },
+  { key: 'billing_zip_code', label: __('Billing Zip Code', 'bit-integrations'), required: false },
+  {
+    key: 'shipping_country_code',
+    label: __('Shipping Country Code', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_locality',
+    label: __('Shipping Country', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_first_address_street',
+    label: __('Shipping Address Street (Line 1)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_second_address_street',
+    label: __('Shipping Address Street (Line 2)', 'bit-integrations'),
+    required: false
+  },
+  {
+    key: 'shipping_zip_code',
+    label: __('Shipping Zip Code', 'bit-integrations'),
+    required: false
+  },
+  { key: 'anniversary', label: __('Anniversary', 'bit-integrations'), required: false },
+  { key: 'birthday', label: __('Birthday', 'bit-integrations'), required: false },
+  { key: 'fax_numbers', label: __('Fax Numbers', 'bit-integrations'), required: false }
+]


### PR DESCRIPTION
## Description

This PR fixes Keap field mapping consistency by centralizing contact field definitions and reusing them during custom field refresh. It prevents mapping drift when users reload Keap custom fields in integration setup.

## Motivation & Context

Keap contact field metadata was defined inside the component only, so refresh flows could miss or desync base contact fields. Exporting and reusing one shared source keeps mapping stable and avoids configuration confusion.

## Related Links: (if applicable)

<!-- Notion issue, feature request, or discussion link -->

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] ⚡ Improvement
- [ ] 🔄 Code refactor

## Key Changes

### **Integrations**

- **Fixed** Keap mapping setup by moving base contact field schema to a shared exported constant.
- **Fixed** Keap custom-field refresh flow to re-attach base contact fields before regenerating field mappings.

### **Frontend**

- **Updated** Keap component to consume shared `contactFields` definition instead of local inline duplication.
- **Improved** mapping reliability after refresh so required/default Keap contact fields stay available.

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated if needed
- [ ] README updated if needed

## Changelog

- **Fix**: Keap contact field mapping now stays consistent after refreshing custom fields.
- **Improvement**: Keap configuration now uses one shared contact field source for more reliable setup.
