### PR TITLE
ci: restore Plugin Check (wp-env tests env) + fix warnings

### DIFF
--- a/backend/Actions/HefflCRM/HefflCRMController.php
+++ b/backend/Actions/HefflCRM/HefflCRMController.php
@@ -116,6 +116,7 @@ class HefflCRMController
         $fieldMap = $integrationDetails->field_map ?? [];
 
         if (empty($fieldMap) || empty($apiKey)) {
+            // translators: %s is the name of the integration.
             return new WP_Error('REQ_FIELD_EMPTY', wp_sprintf(__('API key and field map are required for %s api', 'bit-integrations'), 'Heffl CRM'));
         }
 
@@ -193,8 +194,6 @@ class HefflCRMController
         if (\is_object($response) && !is_wp_error($response) && !empty($response->hasMore) && !empty($response->nextCursor)) {
             return $response->nextCursor;
         }
-
-        return null;
     }
 
     private static function defaultLabel($item, $id)

--- a/backend/Actions/WpDataTables/WpDataTablesController.php
+++ b/backend/Actions/WpDataTables/WpDataTablesController.php
@@ -27,6 +27,7 @@ class WpDataTablesController
         self::isExists();
 
         global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $tables = $wpdb->get_results(
             "SELECT id, title FROM {$wpdb->prefix}wpdatatables ORDER BY id ASC",
             ARRAY_A
@@ -50,6 +51,7 @@ class WpDataTablesController
         }
 
         global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
         $table = $wpdb->get_row(
             $wpdb->prepare(
                 "SELECT content FROM {$wpdb->prefix}wpdatatables WHERE id = %d",

--- a/backend/Actions/ZendeskSupport/RecordApiHelper.php
+++ b/backend/Actions/ZendeskSupport/RecordApiHelper.php
@@ -82,6 +82,7 @@ class RecordApiHelper
 
         $fieldData = $this->generateReqDataFromFieldMap($fieldValues, $fieldMap);
         $utilities = (array) ($this->_integrationDetails->utilities ?? []);
+        // translators: %s is the name of the integration.
         $default = ['success' => false, 'message' => wp_sprintf(__('%s plugin is not installed or activated', 'bit-integrations'), 'Bit Integrations Pro')];
 
         $response = Hooks::apply(


### PR DESCRIPTION
## Description

Restores the **WordPress Plugin Check** CI, which has been failing on every branch (including `main`) since ~2026-05-25, and resolves the plugin-check warnings it surfaces once it runs again.

## Motivation & Context

The `wordpress/plugin-check-action@v1` step installs `@wordpress/env` **unpinned**. Since `@wordpress/env` v11 (late-May 2026), `wp-env start` silently no-ops on CI — it prints only `Reading configuration.`, exits `0` without bringing up Docker, and the next step dies with:

```
✖ Environment not initialized. Run `wp-env start` first.
##[error]Process completed with exit code 1.
```

The breakage comes from the **tests environment**: the now-deprecated default dual dev+tests startup clones `wordpress-develop`, which fails under `simple-git`'s `allowUnsafePack` guard (see [gutenberg#75805](https://github.com/wordpress/gutenberg/issues/75805), [plugin-check#1236](https://github.com/WordPress/plugin-check/issues/1236)). The fix disables the tests environment so only the dev environment starts.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] ⚡ Improvement
- [ ] 🔄 Code refactor

## Key Changes

### **CI / Build**

- **Added** a `Configure wp-env for Plugin Check` step that writes a check-only `.wp-env.json` into the build dir with `"testsEnvironment": false`. The action honors a pre-existing config instead of generating its own, so the file also restores the `plugin-check` plugin and the plugin mapping.
- **Added** `.wp-env.json` to the action's `exclude-files` so the injected config isn't scanned.
- The config is written in the workflow, **not** in `.github/build`, so it never ships to the WordPress.org release (`deploy.yml` reuses that build script).

### **Plugin Check Warnings**

- **Fixed** plugin-check warnings in `WpDataTables`, `Heffl CRM`, and `Zendesk Support` controllers/helpers.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated if needed
- [ ] README updated if needed

## Changelog

- **Fix**: Restored the WordPress Plugin Check CI job (broken by the `@wordpress/env` v11 tests-environment regression).
- **Fix**: Resolved plugin-check warnings in WpDataTables, Heffl CRM, and Zendesk Support.
