### PR TITLE
feat(whatsapp): add template placeholder support (v2.9.2)

### DIFF
--- a/backend/Actions/WhatsApp/RecordApiHelper.php
+++ b/backend/Actions/WhatsApp/RecordApiHelper.php
@@ -8,8 +8,8 @@ namespace BitApps\Integrations\Actions\WhatsApp;
 
 use BitApps\Integrations\Config;
 use BitApps\Integrations\Core\Util\Common;
-use BitApps\Integrations\Core\Util\HttpHelper;
 use BitApps\Integrations\Core\Util\Hooks;
+use BitApps\Integrations\Core\Util\HttpHelper;
 use BitApps\Integrations\Log\LogHandler;
 
 /**
@@ -34,7 +34,8 @@ class RecordApiHelper
         $businessAccountID,
         $token,
         $data,
-        $phoneNumber
+        $phoneNumber,
+        $templatePlaceholders = []
     ) {
         $templateName = $this->_integrationDetails->templateName;
         $apiEndPoint = "{$this->_baseUrl}{$businessAccountID}/message_templates?fields=language&name={$templateName}";
@@ -42,16 +43,28 @@ class RecordApiHelper
         $language = $response->data[0]->language ?? 'en_US';
 
         $apiEndPoint = "{$this->_baseUrl}{$numberId}/messages";
+        $template = [
+            'name'     => $templateName,
+            'language' => [
+                'code' => $language
+            ]
+        ];
+
+        $components = Hooks::apply(Config::withPrefix('whatsapp_template_components'), [], $templatePlaceholders);
+
+        if (!\is_array($components)) {
+            $components = [];
+        }
+
+        if (!empty($components)) {
+            $template['components'] = $components;
+        }
+
         $data = [
             'messaging_product' => 'whatsapp',
             'to'                => "{$phoneNumber}",
             'type'              => 'template',
-            'template'          => [
-                'name'     => $templateName,
-                'language' => [
-                    'code' => $language
-                ]
-            ]
+            'template'          => $template
         ];
 
         return HttpHelper::post($apiEndPoint, $data, static::setHeaders($token));
@@ -137,7 +150,12 @@ class RecordApiHelper
         $token = $this->_integrationDetails->token;
 
         if ($messageType === 'template' || $messageType === '2') {
-            $apiResponse = $this->sendMessageWithTemplate($numberId, $businessAccountID, $token, $finalData, $phoneNumber);
+            $templateFieldMap = isset($this->_integrationDetails->template_field_map)
+                ? $this->_integrationDetails->template_field_map
+                : [];
+            $templatePlaceholders = $this->generateReqDataFromFieldMap($fieldValues, $templateFieldMap);
+
+            $apiResponse = $this->sendMessageWithTemplate($numberId, $businessAccountID, $token, $finalData, $phoneNumber, $templatePlaceholders);
             $typeName = 'Template Message';
         } elseif ($messageType === 'text') {
             $apiResponse = $this->sendMessageWithText($numberId, $fieldValues, $token, $phoneNumber);

--- a/backend/Actions/WhatsApp/RecordApiHelper.php
+++ b/backend/Actions/WhatsApp/RecordApiHelper.php
@@ -40,7 +40,7 @@ class RecordApiHelper
         $templateName = $this->_integrationDetails->templateName;
         $apiEndPoint = "{$this->_baseUrl}{$businessAccountID}/message_templates?fields=language&name={$templateName}";
         $response = HttpHelper::get($apiEndPoint, null, static::setHeaders($token));
-        $language = $response->data[0]->language ?? 'en_US';
+        $language = isset($response->data[0]->language) ? $response->data[0]->language : 'en_US';
 
         $apiEndPoint = "{$this->_baseUrl}{$numberId}/messages";
         $template = [
@@ -150,9 +150,7 @@ class RecordApiHelper
         $token = $this->_integrationDetails->token;
 
         if ($messageType === 'template' || $messageType === '2') {
-            $templateFieldMap = isset($this->_integrationDetails->template_field_map)
-                ? $this->_integrationDetails->template_field_map
-                : [];
+            $templateFieldMap = $this->_integrationDetails->template_field_map ?? [];
             $templatePlaceholders = $this->generateReqDataFromFieldMap($fieldValues, $templateFieldMap);
 
             $apiResponse = $this->sendMessageWithTemplate($numberId, $businessAccountID, $token, $finalData, $phoneNumber, $templatePlaceholders);

--- a/backend/Actions/WhatsApp/WhatsAppController.php
+++ b/backend/Actions/WhatsApp/WhatsAppController.php
@@ -35,7 +35,7 @@ class WhatsAppController
     {
         static::checkValidation($requestParams);
 
-        $apiEndpoint = "{$this->baseUrl}{$requestParams->businessAccountID}/message_templates?fields=name";
+        $apiEndpoint = "{$this->baseUrl}{$requestParams->businessAccountID}/message_templates?fields=name,language,components";
         $allTemplates = static::getTemplate($apiEndpoint, $requestParams->token);
 
         if (is_wp_error($allTemplates)) {
@@ -88,7 +88,11 @@ class WhatsAppController
         }
 
         foreach ($response->data as $template) {
-            $allTemplates[] = $template->name;
+            $allTemplates[] = [
+                'name'       => $template->name,
+                'language'   => isset($template->language) ? $template->language : 'en_US',
+                'components' => isset($template->components) ? $template->components : [],
+            ];
         }
 
         if (isset($response->paging->next)) {

--- a/backend/Config.php
+++ b/backend/Config.php
@@ -22,7 +22,7 @@ class Config
 
     public const VAR_PREFIX = 'bit_integrations_';
 
-    public const VERSION = '2.9.1';
+    public const VERSION = '2.9.2';
 
     public const DB_VERSION = '1.1';
 

--- a/bitwpfi.php
+++ b/bitwpfi.php
@@ -4,7 +4,7 @@
  * Plugin Name: Bit Integrations
  * Plugin URI:  https://bitapps.pro/bit-integrations
  * Description: Bit Integrations is a platform that integrates with over 300+ different platforms to help with various tasks on your WordPress site, like WooCommerce, Form builder, Page builder, LMS, Sales funnels, Bookings, CRM, Webhooks, Email marketing, Social media and Spreadsheets, etc
- * Version:     2.9.1
+ * Version:     2.9.2
  * Author:      Automation & Integration Plugin - Bit Apps
  * Author URI:  https://bitapps.pro
  * Text Domain: bit-integrations
@@ -33,7 +33,7 @@ $btcbi_db_version = '1.1';
  *
  * @deprecated 2.7.8 Use Config::VERSION instead.
  */
-define('BTCBI_VERSION', '2.9.1');
+define('BTCBI_VERSION', '2.9.2');
 /**
  * deprecated since version 2.7.8.
  *

--- a/frontend/src/components/AllIntegrations/WhatsApp/EditWhatsApp.jsx
+++ b/frontend/src/components/AllIntegrations/WhatsApp/EditWhatsApp.jsx
@@ -2,7 +2,7 @@
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import { useRecoilState, useRecoilValue } from 'recoil'
-import { $actionConf, $formFields, $newFlow } from '../../../GlobalStates'
+import { $actionConf, $appConfigState, $formFields, $newFlow } from '../../../GlobalStates'
 import { __ } from '../../../Utils/i18nwrap'
 import SnackMsg from '../../Utilities/SnackMsg'
 import EditFormInteg from '../EditFormInteg'
@@ -22,6 +22,7 @@ function EditWhatsApp({ allIntegURL }) {
   const formFields = useRecoilValue($formFields)
   const [isLoading, setIsLoading] = useState(false)
   const [snack, setSnackbar] = useState({ show: false })
+  const { isPro } = useRecoilValue($appConfigState)
 
   return (
     <div style={{ width: 900 }}>
@@ -66,7 +67,7 @@ function EditWhatsApp({ allIntegURL }) {
             setSnackbar
           })
         }
-        disabled={checkDisabledButton(whatsAppConf) || isLoading}
+        disabled={checkDisabledButton(whatsAppConf, isPro) || isLoading}
         isLoading={isLoading}
         dataConf={whatsAppConf}
         setDataConf={setWhatsAppConf}

--- a/frontend/src/components/AllIntegrations/WhatsApp/WhatsApp.jsx
+++ b/frontend/src/components/AllIntegrations/WhatsApp/WhatsApp.jsx
@@ -62,6 +62,8 @@ function WhatsApp({ formFields, setFlow, flow, allIntegURL }) {
     messageType: '',
     body: '',
     templateName: '',
+    template_fields: [],
+    template_field_map: [],
     token: '',
     field_map: generateMappedField(whatsAppFields),
     whatsAppFields,
@@ -75,7 +77,7 @@ function WhatsApp({ formFields, setFlow, flow, allIntegURL }) {
       document.getElementById('btcd-settings-wrp').scrollTop = 0
     }, 300)
 
-    if (checkDisabledButton(whatsAppConf)) {
+    if (checkDisabledButton(whatsAppConf, isPro)) {
       setSnackbar({ show: true, msg: __('Please map fields to continue.', 'bit-integrations') })
       return
     }
@@ -116,7 +118,7 @@ function WhatsApp({ formFields, setFlow, flow, allIntegURL }) {
 
         <button
           onClick={() => nextPage(3)}
-          disabled={checkDisabledButton(whatsAppConf)}
+          disabled={checkDisabledButton(whatsAppConf, isPro)}
           className="btn f-right btcd-btn-lg purple sh-sm flx"
           type="button">
           {__('Next', 'bit-integrations')} &nbsp;

--- a/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppCommonFunc.js
+++ b/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppCommonFunc.js
@@ -84,13 +84,78 @@ export const getallTemplates = (confTmp, setConf, setIsLoading, setSnackbar) => 
     } else if (result && result.success) {
       setConf(prevConf =>
         create(prevConf, draftConf => {
-          draftConf['allTemplates'] = result?.data || []
+          draftConf['allTemplates'] = normalizeTemplates(result?.data)
         })
       )
       setSnackbar({ show: true, msg: __('Template Fetched Successfully', 'bit-integrations') })
       return
     }
   })
+}
+
+/**
+ * Templates were stored as plain names before placeholder mapping existed,
+ * so old configurations are upgraded to the object shape on the fly.
+ */
+export const normalizeTemplates = templates =>
+  (templates || []).map(template =>
+    typeof template === 'string' ? { name: template, language: '', components: [] } : template
+  )
+
+const PLACEHOLDER_PATTERN = /{{\s*(\w+)\s*}}/g
+
+const extractTokens = (text = '') => {
+  const tokens = []
+
+  for (const match of String(text || '').matchAll(PLACEHOLDER_PATTERN)) {
+    if (!tokens.includes(match[1])) tokens.push(match[1])
+  }
+
+  return tokens
+}
+
+const placeholderLabel = placeholder => {
+  const [section, ...rest] = placeholder.split('.')
+
+  if (section === 'button') {
+    return `${__('Button', 'bit-integrations')} ${Number(rest[0]) + 1} {{${rest[1]}}}`
+  }
+
+  return `${
+    section === 'header' ? __('Header', 'bit-integrations') : __('Body', 'bit-integrations')
+  } {{${rest[0]}}}`
+}
+
+/**
+ * Collects every dynamic placeholder of a template
+ * from its header text, body text and dynamic url buttons.
+ */
+export const extractTemplatePlaceholders = template => {
+  const placeholders = []
+
+  ;(template?.components || []).forEach(component => {
+    const type = component?.type?.toUpperCase()
+
+    if (type === 'HEADER' && component.format === 'TEXT') {
+      extractTokens(component.text).forEach(token => placeholders.push(`header.${token}`))
+    }
+
+    if (type === 'BODY') {
+      extractTokens(component.text).forEach(token => placeholders.push(`body.${token}`))
+    }
+
+    if (type === 'BUTTONS') {
+      component.buttons?.forEach((button, index) => {
+        extractTokens(button?.url).forEach(token => placeholders.push(`button.${index}.${token}`))
+      })
+    }
+  })
+
+  return placeholders.map(placeholder => ({
+    key: placeholder,
+    label: placeholderLabel(placeholder),
+    required: true
+  }))
 }
 
 export const generateMappedField = whatsAppFields => {
@@ -110,12 +175,19 @@ export const checkMappedFields = whatsAppFields => {
   return true
 }
 
-export const checkDisabledButton = whatsAppConf => {
+const hasUnmappedPlaceholder = templateFieldMap =>
+  (templateFieldMap || []).some(field => !field?.formField)
+
+export const checkDisabledButton = (whatsAppConf, isPro = false) => {
   let check = false
 
   if (whatsAppConf?.messageType === '') {
     check = true
-  } else if (whatsAppConf?.messageType === 'template' && whatsAppConf.templateName === '') {
+  } else if (
+    whatsAppConf?.messageType === 'template' &&
+    (whatsAppConf.templateName === '' ||
+      (isPro && hasUnmappedPlaceholder(whatsAppConf.template_field_map)))
+  ) {
     check = true
   } else if (whatsAppConf?.messageType === 'text' && whatsAppConf.body === '') {
     check = true

--- a/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppFieldMap.jsx
+++ b/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppFieldMap.jsx
@@ -87,7 +87,7 @@ export default function WhatsAppFieldMap({
           </select>
         </div>
 
-        {requiredFlds[0]?.key !== 'phone' && (
+        {requiredFlds[0]?.key !== 'phone' && mapKey !== 'template_field_map' && (
           <>
             <button
               onClick={() => addFieldMap(i, whatsAppConf, setWhatsAppConf, mapKey)}

--- a/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppIntegLayout.jsx
+++ b/frontend/src/components/AllIntegrations/WhatsApp/WhatsAppIntegLayout.jsx
@@ -1,12 +1,21 @@
+import { useEffect } from 'react'
 import { create } from 'mutative'
 import MultiSelect from 'react-multiple-select-dropdown-lite'
 import { useParams } from 'react-router'
 import { __ } from '../../../Utils/i18nwrap'
 import Loader from '../../Loaders/Loader'
 import TinyMCE from '../../Utilities/TinyMCE'
-import { addFieldMap, generateMappedField, getallTemplates } from './WhatsAppCommonFunc'
+import {
+  addFieldMap,
+  extractTemplatePlaceholders,
+  generateMappedField,
+  getallTemplates,
+  normalizeTemplates
+} from './WhatsAppCommonFunc'
 import WhatsAppFieldMap from './WhatsAppFieldMap'
 import Note from '../../Utilities/Note'
+import ActionProFeatureComponent from '../IntegrationHelpers/ActionProFeatureComponent'
+import { ProFeatureTitle } from '../IntegrationHelpers/ActionProFeatureLabels'
 import { useRecoilValue } from 'recoil'
 import { $appConfigState } from '../../../GlobalStates'
 import { checkIsPro, getProLabel } from '../../Utilities/ProUtilHelpers'
@@ -30,10 +39,32 @@ export default function WhatsAppIntegLayout({
     setWhatsAppConf(newConf)
   }
 
+  const allTemplates = normalizeTemplates(whatsAppConf?.allTemplates)
+  // Flows saved before placeholder mapping hold template names only, refetch them once to get components
+  useEffect(() => {
+    if (
+      whatsAppConf?.messageType === 'template' &&
+      whatsAppConf?.allTemplates?.length > 0 &&
+      whatsAppConf.allTemplates.some(template => typeof template === 'string')
+    ) {
+      getallTemplates(whatsAppConf, setWhatsAppConf, setIsLoading, setSnackbar)
+    }
+  }, [])
+
   const setChange = (value, name) => {
     setWhatsAppConf(prevConf =>
       create(prevConf, draftConf => {
         draftConf[name] = value
+
+        if (name === 'templateName') {
+          const templateFields = extractTemplatePlaceholders(
+            allTemplates.find(template => template.name === value)
+          )
+
+          draftConf['template_fields'] = templateFields
+          draftConf['template_field_map'] =
+            templateFields.length > 0 ? generateMappedField(templateFields) : []
+        }
 
         if (isPro) {
           if (name === 'messageType' && value === 'text') {
@@ -90,9 +121,9 @@ export default function WhatsAppIntegLayout({
               defaultValue={whatsAppConf?.templateName}
               className="mt-2 w-5"
               onChange={val => setChange(val, 'templateName')}
-              options={whatsAppConf?.allTemplates?.map(templateName => ({
-                label: templateName,
-                value: templateName
+              options={allTemplates.map(template => ({
+                label: template.language ? `${template.name} (${template.language})` : template.name,
+                value: template.name
               }))}
               singleSelect
               closeOnSelect
@@ -177,6 +208,39 @@ export default function WhatsAppIntegLayout({
           setSnackbar={setSnackbar}
         />
       ))}
+
+      {whatsAppConf.messageType === 'template' && whatsAppConf?.template_fields?.length > 0 && (
+        <div className="mt-5">
+          <ActionProFeatureComponent title={__('Template Placeholder Map', 'bit-integrations')}>
+            <b className="wdt-100">
+              <ProFeatureTitle title={__('Template Placeholder Map', 'bit-integrations')} />
+            </b>
+            <div className="btcd-hr mt-2 mb-4" />
+            <div className="flx flx-around mt-2 mb-2 btcbi-field-map-label">
+              <div className="txt-dp">
+                <b>{__('Form Fields', 'bit-integrations')}</b>
+              </div>
+              <div className="txt-dp">
+                <b>{__('Template Placeholders', 'bit-integrations')}</b>
+              </div>
+            </div>
+
+            {whatsAppConf?.template_field_map?.map((itm, i) => (
+              <WhatsAppFieldMap
+                key={`tpl-m-${i + 9}`}
+                i={i}
+                field={itm}
+                whatsAppConf={whatsAppConf}
+                whatsAppFields={whatsAppConf.template_fields}
+                formFields={formFields}
+                setWhatsAppConf={setWhatsAppConf}
+                setSnackbar={setSnackbar}
+                mapKey="template_field_map"
+              />
+            ))}
+          </ActionProFeatureComponent>
+        </div>
+      )}
 
       {whatsAppConf.messageType === 'media' && isPro && whatsAppConf?.media_fields && (
         <>

--- a/frontend/src/pages/ChangelogToggle.jsx
+++ b/frontend/src/pages/ChangelogToggle.jsx
@@ -43,13 +43,8 @@ const changeLog = [
     itemClass: 'feature-list',
     items: [
       {
-        label: 'Salesforce',
-        desc: 'Added record owner selection for supported record creation actions.',
-        isPro: false
-      },
-      {
-        label: 'MemberPress',
-        desc: 'Added Transaction expired trigger event.',
+        label: 'WhatsApp',
+        desc: 'Added template placeholder support and improved template handling in the integration setup.',
         isPro: true
       }
     ]
@@ -64,35 +59,13 @@ const changeLog = [
     label: __('Bug Fixes', 'bit-integrations'),
     headClass: 'fixes',
     itemClass: 'fixes-list',
-    items: [
-      {
-        label: 'ActiveCampaign',
-        desc: 'Improved tag fetching error handling through the shared HTTP helper.',
-        isPro: false
-      }
-    ]
+    items: []
   },
   {
     label: __('Security', 'bit-integrations'),
     headClass: 'fixes',
     itemClass: 'fixes-list',
-    items: [
-      {
-        label: 'Custom Action',
-        desc: 'Added administrator capability checks for creating, updating, duplicating, deleting and toggling custom-action flows.',
-        isPro: false
-      },
-      {
-        label: 'File Handling',
-        desc: 'Hardened attachment and upload path validation for Mail, PropovoiceCRM, SureCart and shared media upload helpers.',
-        isPro: false
-      },
-      {
-        label: 'HTTP Requests',
-        desc: 'Switched external requests to safer URL validation and WordPress safe remote request helpers.',
-        isPro: false
-      }
-    ]
+    items: []
   },
   {
     label: __('Compatibility & Compliance', 'bit-integrations'),

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Bit integrations - Form Integration, Webhook, Spreadsheets, CRM, LMS & Email Automation ===
-Contributors: bitpressadmin, akaioum, rishadbitcode, niloy121, fahimsakib, shuvomohajan, tanvirchy, shakhawathosen, khoaiz, mazharul78
+Contributors: bitpressadmin
 Tags: automation, automator, google sheets integration, form integration, WooCommerce Integration
 Requires at least: 5.1
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 2.9.1
+Stable tag: 2.9.2
 License: GPLv2 or later
 
 Contact Form, Google Sheet, MailChimp, Brevo, Webhook, Zoho CRM Automation and Integration plugin that Connect 360+ platforms
@@ -467,6 +467,12 @@ Bit Integrations follows WordPress coding standards and best practices to ensure
 6. All integration list
 
 == Changelog ==
+
+= 2.9.2 =
+_Release Date - 21st July 2026_
+
+- **New Feature**
+ - WhatsApp: Added template placeholder support and improved template handling in the integration setup (Pro).
 
 = 2.9.1 =
 _Release Date - 13th July 2026_


### PR DESCRIPTION
## Description

Adds dynamic template placeholder support to the WhatsApp action and ships the 2.9.2 release. Users can now map fields into WhatsApp template header, body, and dynamic URL button placeholders (`{{token}}`), instead of sending template messages with static content only.

## Motivation & Context

WhatsApp Cloud API templates support dynamic components, but the integration previously sent templates with name + language only — no way to fill `{{1}}`, `{{2}}` etc. This adds a placeholder → field mapping UI and passes resolved `components` to the API. Old configs storing templates as plain strings are normalized on the fly for backward compatibility.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] ⚡ Improvement
- [ ] 🔄 Code refactor

## Key Changes

### **Backend (WhatsApp Action)**

- **Added** `templatePlaceholders` handling in `RecordApiHelper::sendMessageWithTemplate` — builds template `components` via `whatsapp_template_components` filter and resolves from `template_field_map`.

### **Frontend (WhatsApp)**

- **Added** `extractTemplatePlaceholders` / `normalizeTemplates` helpers — parse `{{token}}` from header, body, and dynamic URL buttons; upgrade legacy string templates to object shape.
- **Updated** IntegLayout / FieldMap / Edit views to expose the placeholder → field mapping UI.

### **Release**

- **Bumped** version to 2.9.2 (`bitwpfi.php`, `Config.php`), added `readme.txt` changelog entry, refreshed in-app `ChangelogToggle`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated if needed
- [x] README updated if needed

## Changelog

- **Feature**: WhatsApp — map fields into template header, body, and dynamic button placeholders.
- **Improvement**: WhatsApp — legacy plain-name templates auto-upgraded for placeholder support.
