### PR TITLE
feat(oauth): serve OAuth2 redirects from a dedicated route

### DIFF
--- a/backend/Actions/ActionController.php
+++ b/backend/Actions/ActionController.php
@@ -2,61 +2,24 @@
 
 namespace BitApps\Integrations\Actions;
 
-use FilesystemIterator;
+use BitApps\Integrations\Core\Http\OauthCallbackController;
 use WP_Error;
 use WP_REST_Request;
 
 final class ActionController
 {
     /**
-     * Lists available actions
-     *
-     * @return JSON|WP_Error
+     * Legacy OAuth redirect endpoint, kept for apps still registered with it.
      */
-    // public function list()
-    // {
-    //     $actions = [];
-    //     $dirs = new FilesystemIterator(__DIR__);
-    //     foreach ($dirs as $dirInfo) {
-    //         if ($dirInfo->isDir()) {
-    //             $action = basename($dirInfo);
-    //             if (
-    //                 file_exists(__DIR__ . '/' . $action)
-    //                 && file_exists(__DIR__ . '/' . $action . '/' . $action . 'Controller.php')
-    //             ) {
-    //                 $action_controller = __NAMESPACE__ . "\\{$action}\\{$action}Controller";
-    //                 if (method_exists($action_controller, 'info')) {
-    //                     $actions[$action] = $action_controller::info();
-    //                 }
-    //             }
-    //         }
-    //     }
-    //     return $actions;
-    // }
-
     public function handleRedirect(WP_REST_Request $request)
     {
         $state = $request->get_param('state');
 
-        if (static::getHostWithPort($state) !== static::getHostWithPort(get_site_url())) {
-            return new WP_Error('404');
-        }
-
         $params = $request->get_params();
         unset($params['rest_route'], $params['state']);
 
-        wp_safe_redirect($state . '&' . http_build_query($params), 302);
-        exit;
-    }
-
-    public static function getHostWithPort($url)
-    {
-        $parsed_url = wp_parse_url($url);
-
-        if (!\is_array($parsed_url) || empty($parsed_url['host'])) {
-            return '';
+        if (!OauthCallbackController::redirectToState($state, $params)) {
+            return new WP_Error('invalid_state', __('Invalid redirect state.', 'bit-integrations'), ['status' => 404]);
         }
-
-        return $parsed_url['host'] . (empty($parsed_url['port']) ? '' : (':' . $parsed_url['port']));
     }
 }

--- a/backend/Config.php
+++ b/backend/Config.php
@@ -4,6 +4,7 @@
 
 namespace BitApps\Integrations;
 
+use BitApps\Integrations\Core\Http\OauthCallbackController;
 use BitApps\Integrations\Core\Util\DateTimeHelper;
 use BitApps\Integrations\Core\Util\FileSystem;
 use BitApps\Integrations\Core\Util\Hooks;
@@ -70,6 +71,17 @@ class Config
 
             case 'API_URL':
                 return get_rest_url(null, '/' . self::SLUG . '/v1');
+
+            case 'OAUTH_CALLBACK_URI':
+                if (get_option('permalink_structure') === '') {
+                    return home_url('/?pagename=' . OauthCallbackController::pagename());
+                }
+
+                return home_url('/' . OauthCallbackController::ROUTE . '/');
+
+            case 'REDIRECT_URI':
+                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- hook is prefixed via Config::VAR_PREFIX.
+                return Hooks::apply(self::withPrefix('oauth_redirect_uri'), self::get('OAUTH_CALLBACK_URI'));
 
             case 'WP_API_URL':
                 return [
@@ -200,6 +212,7 @@ class Config
                 'siteURL'     => site_url(),
                 'ajaxURL'     => admin_url('admin-ajax.php'),
                 'api'         => self::get('API_URL'),
+                'redirectURI' => self::get('REDIRECT_URI'),
                 'wp_api_url'  => self::get('WP_API_URL'),
                 'dateFormat'  => get_option('date_format'),
                 'timeFormat'  => get_option('time_format'),

--- a/backend/Core/Http/OauthCallbackController.php
+++ b/backend/Core/Http/OauthCallbackController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BitApps\Integrations\Core\Http;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use BitApps\Integrations\Config;
+use BitApps\Integrations\Core\Util\RewriteRuleProvider;
+use WP;
+
+/**
+ * Serves `/{slug}/oauth-callback/`, forwarding an OAuth provider callback to the
+ * admin URL carried in `state`. Providers reject a `redirect_uri` containing a
+ * fragment, which the hash-routed admin app needs.
+ */
+final class OauthCallbackController
+{
+    public const ROUTE = Config::SLUG . '/oauth-callback';
+
+    /**
+     * `parse_request` runs before the main query and before `redirect_canonical`,
+     * which could otherwise rewrite the URL through 404 handling.
+     *
+     * @param WP $wp
+     *
+     * @return void
+     */
+    public function handle($wp)
+    {
+        $pagename = isset($wp->query_vars['pagename']) ? $wp->query_vars['pagename'] : '';
+
+        if ($pagename !== self::pagename()) {
+            return;
+        }
+
+        header('X-Robots-Tag: noindex, nofollow');
+        nocache_headers();
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- OAuth providers redirect here without a nonce; see above for why values are not sanitized.
+        $params = wp_unslash($_GET);
+
+        $state = isset($params['state']) ? $params['state'] : '';
+
+        unset($params['state'], $params['pagename'], $params['rest_route']);
+
+        self::redirectToState($state, $params);
+    }
+
+    /**
+     * @return string
+     */
+    public static function pagename()
+    {
+        return RewriteRuleProvider::pagenameFor(self::ROUTE);
+    }
+
+    /**
+     * Redirects to $state with $params appended. Exits the request on success.
+     * Rejecting off-site $state keeps this from becoming an open redirect.
+     *
+     * @param mixed $state
+     * @param array $params
+     *
+     * @return bool
+     */
+    public static function redirectToState($state, array $params)
+    {
+        if (!\is_string($state) || $state === '') {
+            return false;
+        }
+
+        if (self::hostWithPort($state) !== self::hostWithPort(get_site_url())) {
+            return false;
+        }
+
+        if ($params !== []) {
+            $separator = strpos($state, '?') === false ? '?' : '&';
+            $state .= $separator . http_build_query($params);
+        }
+
+        if (wp_safe_redirect($state, 302)) {
+            exit;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return string
+     */
+    public static function hostWithPort($url)
+    {
+        $parsedUrl = wp_parse_url($url);
+
+        if (!\is_array($parsedUrl) || empty($parsedUrl['host'])) {
+            return '';
+        }
+
+        return $parsedUrl['host'] . (empty($parsedUrl['port']) ? '' : (':' . $parsedUrl['port']));
+    }
+}

--- a/backend/Core/Util/Deactivation.php
+++ b/backend/Core/Util/Deactivation.php
@@ -43,5 +43,11 @@ final class Deactivation
     public function deactive()
     {
         wp_clear_scheduled_hook('btcbi_delete_integ_log');
+
+        // Drops the OAuth callback rewrite rule, which would otherwise keep
+        // resolving to a pagename nothing handles. Clearing the lock lets a
+        // reactivation restore the rule without waiting it out.
+        delete_transient(Config::withPrefix(RewriteRuleProvider::FLUSH_LOCK));
+        flush_rewrite_rules();
     }
 }

--- a/backend/Core/Util/Request.php
+++ b/backend/Core/Util/Request.php
@@ -23,4 +23,27 @@ final class Request
                 return (! is_admin() || \defined('DOING_AJAX')) && ! \defined('DOING_CRON');
         }
     }
+
+    /**
+     * Detects a REST request before `REST_REQUEST` is defined, which core only
+     * does once `parse_request` runs.
+     *
+     * @return bool
+     */
+    public static function isRest()
+    {
+        if (\defined('REST_REQUEST')) {
+            return true;
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only request-type probe, no data is used.
+        if (isset($_GET['rest_route'])) {
+            return true;
+        }
+
+        $requestUri = isset($_SERVER['REQUEST_URI']) ? sanitize_text_field(wp_unslash($_SERVER['REQUEST_URI'])) : '';
+
+        // Not anchored: subdirectory installs serve REST under the site path.
+        return strpos($requestUri, '/' . rest_get_url_prefix() . '/') !== false;
+    }
 }

--- a/backend/Core/Util/RewriteRuleProvider.php
+++ b/backend/Core/Util/RewriteRuleProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace BitApps\Integrations\Core\Util;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use BitApps\Integrations\Config;
+
+/**
+ * Maps a plugin route to WordPress' `pagename` query var, so a controller can
+ * intercept it without a real page or a REST namespace.
+ */
+final class RewriteRuleProvider
+{
+    public const FLUSH_LOCK = 'rewrite_flush_lock';
+
+    /**
+     * @var string
+     */
+    private $route;
+
+    public function __construct($route)
+    {
+        $this->route = trim($route, '/');
+    }
+
+    /**
+     * @param string $route
+     *
+     * @return string
+     */
+    public static function pagenameFor($route)
+    {
+        return str_replace('/', '-', trim($route, '/'));
+    }
+
+    public function register()
+    {
+        Hooks::add('init', [$this, 'addRule']);
+    }
+
+    public function addRule()
+    {
+        $regex = '^' . $this->route . '/?$';
+
+        add_rewrite_rule($regex, 'index.php?pagename=' . self::pagenameFor($this->route), 'top');
+
+        $rules = get_option('rewrite_rules');
+
+        // A permalink change or another plugin's flush can drop the rule.
+        if (!\is_array($rules) || isset($rules[$regex])) {
+            return;
+        }
+
+        // Rate limited: a plugin that flushes on every `init` before this one runs
+        // would otherwise leave the rule permanently missing and flush each request.
+        $lock = Config::withPrefix(self::FLUSH_LOCK);
+
+        if (get_transient($lock)) {
+            return;
+        }
+
+        set_transient($lock, 1, HOUR_IN_SECONDS);
+
+        flush_rewrite_rules();
+    }
+}

--- a/backend/Plugin.php
+++ b/backend/Plugin.php
@@ -11,11 +11,13 @@ namespace BitApps\Integrations;
 use BitApps\Integrations\Admin\Admin_Bar;
 use BitApps\Integrations\Core\Database\DB;
 use BitApps\Integrations\Core\Hooks\HookService;
+use BitApps\Integrations\Core\Http\OauthCallbackController;
 use BitApps\Integrations\Core\Util\Activation;
 use BitApps\Integrations\Core\Util\Capabilities;
 use BitApps\Integrations\Core\Util\Deactivation;
 use BitApps\Integrations\Core\Util\Hooks;
 use BitApps\Integrations\Core\Util\Request;
+use BitApps\Integrations\Core\Util\RewriteRuleProvider;
 use BitApps\Integrations\Core\Util\UnInstallation;
 use BitApps\Integrations\Log\LogHandler;
 
@@ -39,6 +41,8 @@ final class Plugin
     {
         Hooks::add('plugins_loaded', [$this, 'init_plugin'], 12);
 
+        $this->registerOauthCallbackRoute();
+
         (new Activation())->activate();
         (new Deactivation())->register();
         (new UnInstallation())->register();
@@ -54,6 +58,24 @@ final class Plugin
         new HookService();
 
         $this->deleteLogScheduler();
+    }
+
+    /**
+     * @return void
+     */
+    public function registerOauthCallbackRoute()
+    {
+        if (Request::Check('ajax') || Request::Check('cron') || Request::isRest()) {
+            return;
+        }
+
+        Hooks::add('parse_request', [new OauthCallbackController(), 'handle']);
+
+        if (get_option('permalink_structure') === '') {
+            return;
+        }
+
+        (new RewriteRuleProvider(OauthCallbackController::ROUTE))->register();
     }
 
     public function every_week_time_cron($schedules)

--- a/frontend/src/Utils/oauthHelper.js
+++ b/frontend/src/Utils/oauthHelper.js
@@ -29,7 +29,9 @@ export const generateCodeChallengeS256 = async codeVerifier => {
   return base64UrlEncode(new Uint8Array(digest))
 }
 
+// PHP picks the active endpoint; the fallback covers configs localized before it existed.
 export const getRedirectUri = () => {
+  if (APP_CONFIG?.redirectURI) return APP_CONFIG.redirectURI
   const api = (APP_CONFIG?.api || '').replace(/\/+$/, '')
   return `${api}/redirect`
 }

--- a/frontend/src/components/AllIntegrations/IntegInfo.jsx
+++ b/frontend/src/components/AllIntegrations/IntegInfo.jsx
@@ -8,10 +8,9 @@ import { Link, useNavigate, useParams } from 'react-router'
 import useFetch from '../../hooks/useFetch'
 import bitsFetch from '../../Utils/bitsFetch'
 import { __ } from '../../Utils/i18nwrap'
+import { getRedirectUri } from '../../Utils/oauthHelper'
 import Note from '../Utilities/Note'
 import SnackMsg from '../Utilities/SnackMsg'
-import { useRecoilValue } from 'recoil'
-import { $appConfigState } from '../../GlobalStates'
 import { ConnectionSwitchProvider } from '../Connections/ConnectionSwitchContext'
 
 const Loader = lazy(() => import('../Loaders/Loader'))
@@ -761,7 +760,6 @@ const getUpdateAction = confType => {
 
 export default function IntegInfo() {
   const { id, type } = useParams()
-  const btcbi = useRecoilValue($appConfigState)
   const [snack, setSnackbar] = useState({ show: false })
   const [integrationConf, setIntegrationConf] = useState({})
   const [integration, setIntegration] = useState(null)
@@ -857,11 +855,7 @@ export default function IntegInfo() {
     ]
   )
 
-  // route is info/:id but for redirect uri need to make new/:type
-  // let location = window.location.toString()
-  // const toReplaceInd = location.indexOf('/info')
-  // location = window.encodeURI(`${location.slice(0, toReplaceInd)}/new/${type}`)
-  let location = `${btcbi.api}/redirect`
+  const location = getRedirectUri()
   return (
     <>
       <SnackMsg snack={snack} setSnackbar={setSnackbar} />


### PR DESCRIPTION
## Description

Adds a dedicated OAuth2 redirect endpoint at `/bit-integrations/oauth-callback/` and makes it the URI the plugin hands to providers. The legacy REST endpoint `wp-json/bit-integrations/v1/redirect` stays registered and shares the same implementation, so apps still configured with it keep working.

## Motivation & Context

The admin app is hash-routed, so a provider can never redirect straight to it — every OAuth flow has to bounce through a proxy endpoint that forwards the callback params to the URL carried in `state`. That proxy lived under `wp-json`, which some providers reject as a `redirect_uri` and which reads as an API path rather than a plugin route. Bit-Pi already serves this from a rewrite-rule route; this brings Bit Integrations in line.

While wiring it up, the redirect URI turned out to be hardcoded as `${btcbi.api}/redirect` in four separate frontend files, so it now comes from one place in PHP and is filterable.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] ⚡ Improvement
- [x] 🔄 Code refactor

## ⚠️ Breaking Change

The redirect URI sent to OAuth providers changes:

```
before: https://site.com/wp-json/bit-integrations/v1/redirect
after:  https://site.com/bit-integrations/oauth-callback/
```

That URI is registered inside the user's own OAuth app (Google Cloud Console, Zoho, Facebook, …), which we cannot update for them. **Existing users must add the new URI to their app before their next re-authorization**, or it fails with `redirect_uri_mismatch`. Existing tokens and refreshes are unaffected — only the authorization-code step sends `redirect_uri`.

Both endpoints work, so a site can pin back to the old one:

```php
add_filter('bit_integrations_oauth_redirect_uri', function () {
    return BitApps\Integrations\Config::get('API_URL') . '/redirect';
});
```

## Key Changes

### **Backend**

- **Added** `Core\Http\OauthCallbackController` — serves the new route, forwards provider params onto the `state` URL, and exposes `redirectToState()` shared by both endpoints.
- **Added** `Core\Util\RewriteRuleProvider` — maps a plugin route to WordPress' `pagename` query var, with a self-heal that re-flushes when another plugin drops the rule, rate limited to one flush per hour.
- **Added** `Config::get('OAUTH_CALLBACK_URI')` and `Config::get('REDIRECT_URI')`, the latter filterable via `bit_integrations_oauth_redirect_uri` and localized to the frontend as `redirectURI`.
- **Added** `Request::isRest()` — detects a REST request before `REST_REQUEST` is defined, since that only happens once `parse_request` runs.
- **Updated** the handler to run on `parse_request` rather than `template_include`, so it resolves before the main query and before `redirect_canonical` can rewrite the URL through 404 handling.
- **Updated** `Deactivation` to flush rewrite rules, so the route does not linger in the `rewrite_rules` option after deactivating.

### **Frontend**

- **Updated** four hardcoded `${btcbi.api}/redirect` sites to read the single `getRedirectUri()` helper, which now prefers the localized `redirectURI`.

### **Security**

- **Added** rejection of any `state` whose host and port differ from the site — `javascript:`, protocol-relative and userinfo-prefixed URLs are all refused before `wp_safe_redirect()`.
- **Added** `X-Robots-Tag: noindex, nofollow` and `nocache_headers()` on the callback, so a shared proxy cannot cache one user's redirect and replay it to the next.

### **Bug fixes in the legacy endpoint**

- **Fixed** the redirect URL being joined with a hardcoded `&`, which produced a malformed URL for any `state` without a `?`.
- **Fixed** a rejected state returning HTTP 500 with an empty body instead of a 404 with a message.
- **Removed** a commented-out `list()` method, an orphaned `FilesystemIterator` import and an unused `getHostWithPort()` helper.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] Documentation updated if needed
- [ ] README updated if needed

## Testing

Verified against a local install with pretty permalinks:

| Case | Result |
|---|---|
| New route with `code` + `scope` | 302 to the admin URL, params appended after the hash |
| Plain-permalink form `?pagename=…` | 302, identical `Location` |
| Legacy REST route | 302, byte-identical to before this PR |
| Params containing encoded characters | Preserved, and identical across both endpoints |
| Off-site, protocol-relative and userinfo `state` | 404, no redirect |
| Missing `state` | 404 |
| Rewrite rule deleted by hand, then a page load | Rule restored, flush lock set |
| `/wp-json/`, `?rest_route=/`, `wp-login.php` | 200, unaffected |

## Changelog

- **New Feature**
 - OAuth: Authorizations now redirect through `/bit-integrations/oauth-callback/` instead of a `wp-json` URL. Add the new redirect URL to your app in the provider's console before re-authorizing; the old URL keeps working for apps already set up with it.

- **Improvement**
 - OAuth: The redirect URL is now filterable through `bit_integrations_oauth_redirect_uri`.
 - OAuth: Callback responses are marked no-index and no-store.

- **Bug Fixes**
 - OAuth: Fixed a malformed redirect when the return URL carried no query string.
