### PR TITLE
docs(skills): add trigger and action Users Guide doc generators

### DIFF
--- a/.claude/skills/create-action-doc/SKILL.md
+++ b/.claude/skills/create-action-doc/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: create-action-doc
+description: Generate one Bit Integrations Users Guide draft doc for an action integration, including auth-aware connection instructions, mined from the free/pro PHP action code and the React integration UI. Use when the user invokes /create-action-doc with a platform name only or asks to document/generate docs for an action integration only.
+---
+
+# Create Action Doc
+
+Generates **one** Users Guide doc for a platform's actions: the full setup flow
+is walked through step by step, every action event is listed in a collapsible
+"See all available `<Platform>` action events in Bit Integrations" accordion, the
+authorization section is derived from the integration's real auth code, and the
+result is created as a draft EazyDocs child post under the **Actions** section on
+`bit-integrations.com`.
+
+Output must match the shape of the already-published action docs at
+`https://bit-integrations.com/wp-docs/actions/`. The canonical example to follow
+is
+`https://bit-integrations.com/wp-docs/actions/bit-crm-integration-as-an-action/`
+(post ID `124666`).
+
+The **entire document** must be SEO-friendly and user-friendly — not just the
+title. See the writing standards at the top of [reference.md](reference.md).
+
+## Invocation
+
+```text
+/create-action-doc <platform-name>
+```
+
+- `platform-name` is either the **directory name** under `backend/Actions/`,
+  `../bit-integrations-pro/backend/Actions/`, or
+  `frontend/src/components/AllIntegrations/` (e.g. `ZohoCRM`, `BitCrm`,
+  `MondayCom`), or the **display name** from the `integs` array in
+  `frontend/src/components/Flow/New/SelectAction.jsx` (e.g. `Zoho CRM`,
+  `Bit CRM`, `Monday.Com`).
+
+If `platform-name` is missing, ask before doing anything. Do not ask for the
+parent section post ID; read it from `DOC_ACTION_PARENT_POST_ID` in `.env`.
+
+## Prerequisites
+
+Verify first. Abort with the exact fix if missing.
+
+1. `.env` at the plugin root contains `DOC_SITE_URL`, `DOC_SITE_USERNAME`,
+   `DOC_SITE_PASSWORD`, `DOC_ACTION_PARENT_POST_ID`, and
+   `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`. Copy `.env.example` to `.env` and fill
+   it if absent. Never print `DOC_SITE_PASSWORD`; HTTPS only.
+2. `DOC_SITE_PASSWORD` must be a WordPress **Application Password**, not the
+   wp-admin login password.
+3. `DOC_SITE_USERNAME` must be an Administrator or otherwise hold the EazyDocs
+   `edit_docs`/`publish_docs` capabilities. The `create-child` endpoint uses a
+   publish-permission check and returns 403 without them.
+
+## Workflow
+
+1. **Resolve the platform.** Find its entry in the `integs` array in
+   `frontend/src/components/Flow/New/SelectAction.jsx` —
+   `{ type: '<Display Name>', logo?: '<key>', is_pro: bool }`. The `type` value
+   is the authoritative public platform name used in the title, slug, and body.
+   Then locate the code:
+   - backend: `backend/Actions/<Name>/` (free) or
+     `../bit-integrations-pro/backend/Actions/<Name>/` (pro)
+   - frontend: `frontend/src/components/AllIntegrations/<Name>/`
+   The class-name-to-display-name mismatches handled by the switch in
+   `Flow::execute()` (e.g. `Monday.Com` → `MondayCom`) apply here too — check it
+   when the directory name is not an obvious slug of the display name.
+2. **Read the existing doc link.** `frontend/src/Utils/StaticData/tutorialLinks.js`
+   maps a camelCase key to `{ youTubeLink, docLink }`. If `docLink` already
+   points at a live doc, say so and confirm with the user before creating a
+   second one.
+3. **Collect the action event list** from
+   `frontend/src/components/AllIntegrations/<Name>/staticData.js` (or
+   `<Name>Actions.jsx` / `options.js` in older integrations) — entries are
+   `{ name, label, is_pro }`. The `label` strings are the exact event names;
+   never invent or reword them. Note every `is_pro: true` event: it must be
+   marked `(PRO)` in the doc.
+4. **Derive the authorization flow.** Read
+   `frontend/src/components/AllIntegrations/<Name>/<Name>Authorization.jsx`:
+   - Modern integrations render the shared
+     `frontend/src/components/Connections/Authorization.jsx` with an
+     `authDetails.authType` from `AUTH_TYPES` in
+     `frontend/src/Utils/connectionAuth.js` (`wp_plugin_check`, `oauth2`,
+     `oauth1`, `api_key`, `bearer_token`, `basic_auth`, `custom`), plus
+     `noteDetails.note` — quote that note.
+   - Older integrations render bespoke inputs; read their labels and
+     placeholders directly.
+   Map the auth type to the sentences in [reference.md](reference.md).
+   Cross-check the backend handler
+   (`backend/Actions/<Name>/<Name>Controller.php`, usually
+   `checkAuthorization` / `authorize`) and `Routes.php` for what is actually
+   required.
+5. **Collect the configuration fields** from
+   `frontend/src/components/AllIntegrations/<Name>/<Name>IntegLayout.jsx` (and
+   `<Name>FieldMap.jsx` / `<Name>CommonFunc.js` when present): field labels,
+   helper text, required flags, dropdown option sources, and which fields are
+   mapped rather than typed. Read `RecordApiHelper.php` for which fields the API
+   call actually requires.
+6. **Read the wizard shape** from
+   `frontend/src/components/AllIntegrations/<Name>/<Name>.jsx` — the
+   `<Steps step={N} …/>` count tells you how many wizard steps the reader will
+   see. The final screen is
+   `frontend/src/components/AllIntegrations/IntegrationHelpers/IntegrationStepThree.jsx`:
+   the **Conditional Logics** checkbox, the `Successfully Integrated` heading and
+   the **Finish & Save ✔** button.
+7. **Collect trigger plugins for the use-case section** from the trigger
+   registry `backend/Core/Util/AllTriggersName.php` — use real `name` values
+   only (Bit Form, Contact Form 7, Gravity Forms, WPForms, Fluent Forms,
+   Elementor, WooCommerce, …).
+8. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
+   secondary/sidebar title, in-content H1, the mandatory TL;DR paragraph,
+   overview paragraphs, the
+   `How the <Platform> Action Works` and `Before You Start` H2 sections, the
+   `How to Set Up ... in Bit Integrations` H2, sequential Title Case
+   `Step N: ...` H3 headings, the event accordion, the Step 5
+   `Field | What to Set` table, and the `Explore <N> Useful ... Ideas` H2
+   section.
+   Apply the SEO and readability standards at the top of `reference.md` as you
+   write, not as a pass afterwards.
+9. **Resolve media.** Read attachment post IDs from `.env` and resolve each
+   through `GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>`. Every
+   `{{PLACEHOLDER:<slot>}}` uses `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`. Do not
+   upload or cache images.
+10. **Read the parent section post ID** from `DOC_ACTION_PARENT_POST_ID` in
+    `.env` (the `Actions` section, currently `2654`).
+11. **Preview for approval before creating the doc:** WordPress/public post
+    title, EazyDocs secondary/sidebar title, slug, auth type and credential
+    labels used, AI-inferred credential-retrieval steps **flagged for
+    verification**, action event count, Pro-only events, the numbered H3 step
+    titles, the trigger plugins named in the use-case section,
+    internal/external links added, media IDs used, and the parent section id.
+    Each use-case title is a link to its
+    `bit-integrations.com/triggers/<trigger-plugin>/connect/<platform>/` page —
+    note the trigger plugin comes first even in an action doc. List those URLs
+    in the preview with the `<title>` each one returned, because that site
+    soft-404s and a `200` alone does not prove a page exists. See the
+    "Use-case title link" section of `reference.md`.
+    Include an **SEO/readability self-check** in the preview, confirming against
+    the standards in `reference.md`. Report it in four groups:
+    - *Accuracy* — every action-event label, credential field and button text
+      traced to a source file; no behavior borrowed from another platform;
+      every `[VERIFY: …]` flag listed, especially platform-side navigation;
+      Pro/plan gating stated where it matters.
+    - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
+      the meta description and exactly one image alt; one H1, no skipped heading
+      levels; link count; no duplicated content with the platform's trigger doc.
+    - *Extractability* — every heading answered in its first one or two
+      sentences; no orphan pronouns; platform name repeated in each major
+      section; specifics in tables not prose; no hedging words.
+    - *Readability* — paragraph and sentence length, active voice, second
+      person, every image alt filled, no banned words (`simply`, `just`,
+      `easy`, `seamlessly`, …), every step imperative with an observable result.
+    The whole doc is public-facing; get explicit approval on the title and the
+    self-check before creating anything.
+12. **Create a draft child doc** through EazyDocs using the full public title and
+    set its Gutenberg content. Set `ezd_doc_secondary_title` to the platform name
+    as a **top-level** REST field through `wp/v2/docs/<id>` (a `meta.*` payload is
+    ignored). Confirm the field exists in the authenticated `OPTIONS` schema
+    first — it is exposed by a site-specific snippet, not by EazyDocs Pro itself.
+    Only when the field is absent from the schema, report the edit link and ask
+    the user to set the EazyDocs Pro **Secondary Title** field manually, and do
+    not report the sidebar-title work complete until the user confirms it was
+    saved. Also report which placeholder screenshots need replacement, and every
+    `[VERIFY: …]` flag still in the body — the draft must not go public until
+    all of them are resolved and removed.
+13. **Set the Rank Math SEO fields** on the created doc automatically (no
+    approval), via one authenticated
+    `POST $DOC_SITE_URL/wp-json/rankmath/v1/updateMeta` call. Rank Math writes
+    generic post meta, so this works on the EazyDocs `docs` post. Send
+    `objectID` = the doc post ID, `objectType` = `post`, and a `meta` object
+    with:
+    - `rank_math_focus_keyword`: 3-4 comma-separated keyword phrases derived from
+      the doc (platform name + "integration" + the automation value), **most
+      important first** — the first phrase is the primary keyword Rank Math
+      scores on. Example for Zoho CRM: `zoho crm integration, zoho crm bit
+      integrations, zoho crm automation, form to crm`. (Multiple keywords need
+      Rank Math Pro; on free only the first is used, which is why the primary
+      must be first.)
+    - `rank_math_description`: an AI-written meta description. **Do not open with
+      the post title or the phrase "<Platform> Integration as an Action"** —
+      start with the platform name early, then weave **semantic keywords** for
+      the use case (connect, sync, automate, workflow, plus domain terms like
+      "CRM contacts", "form submissions", "order data"). Mention Bit Integrations
+      **once, briefly**, and include the primary focus keyword naturally so Rank
+      Math scores it green.
+      **150-160 characters, hard ceiling 160 — never exceed it.** Count the
+      characters and trim to <=160 before sending.
+    Write the keywords first, then compose the description to contain the primary
+    keyword. If the `rankmath/v1/updateMeta` route returns 404, report it and
+    skip — do not fail the doc.
+14. **Offer the code follow-up.** After the draft is created, report the future
+    public URL and offer to update the `docLink` for this platform in
+    `frontend/src/Utils/StaticData/tutorialLinks.js`. Only edit the JS when the
+    user says yes.
+
+## Notes
+
+- Read [reference.md](reference.md) only after the platform, its auth type, and
+  its action event list are known.
+- Event labels, field labels, and button text must be copied from the code, not
+  paraphrased. Credential facts must come from the integration's own note/helper
+  text; general knowledge may only fill navigation gaps on the third-party site
+  and must be flagged for human verification.
+- Do not touch existing/previously created docs unless explicitly asked.

--- a/.claude/skills/create-action-doc/SKILL.md
+++ b/.claude/skills/create-action-doc/SKILL.md
@@ -166,7 +166,15 @@ Verify first. Abort with the exact fix if missing.
       imperative with an observable result.
     - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
       each one warns about) and the use-case cards, with counts. No fourth block
-      style, nothing boxed outside those three.
+      style, nothing boxed outside those three. Confirm each one carries its
+      `bi-tldr`/`bi-warn`/`bi-card` class and **no inline colour**, and that the
+      `<style>` block is present as the first block of the content — inline
+      colours cannot express the site's dark mode.
+    - *Dark mode* — confirm the doc renders in **both** modes. After publishing,
+      load the page, toggle `body_dark`, and check the computed contrast of every
+      `td/th/p/li/a/h1-h4` against its composited background; report the count of
+      pairs under 4.5:1 in each mode. Markup alone does not prove this — a theme
+      `!important` rule can beat a correct-looking declaration.
     The whole doc is public-facing; get explicit approval on the title and the
     self-check before creating anything.
 12. **Create a draft child doc** through EazyDocs using the full public title and

--- a/.claude/skills/create-action-doc/SKILL.md
+++ b/.claude/skills/create-action-doc/SKILL.md
@@ -18,7 +18,7 @@ is
 `https://bit-integrations.com/wp-docs/actions/bit-crm-integration-as-an-action/`
 (post ID `124666`).
 
-The **entire document** must be SEO-friendly and user-friendly — not just the
+The **entire document** must be SEO-friendly and user-friendly - not just the
 title. See the writing standards at the top of [reference.md](reference.md).
 
 ## Invocation
@@ -56,7 +56,7 @@ Verify first. Abort with the exact fix if missing.
 ## Workflow
 
 1. **Resolve the platform.** Find its entry in the `integs` array in
-   `frontend/src/components/Flow/New/SelectAction.jsx` —
+   `frontend/src/components/Flow/New/SelectAction.jsx` -
    `{ type: '<Display Name>', logo?: '<key>', is_pro: bool }`. The `type` value
    is the authoritative public platform name used in the title, slug, and body.
    Then locate the code:
@@ -64,7 +64,7 @@ Verify first. Abort with the exact fix if missing.
      `../bit-integrations-pro/backend/Actions/<Name>/` (pro)
    - frontend: `frontend/src/components/AllIntegrations/<Name>/`
    The class-name-to-display-name mismatches handled by the switch in
-   `Flow::execute()` (e.g. `Monday.Com` → `MondayCom`) apply here too — check it
+   `Flow::execute()` (e.g. `Monday.Com` → `MondayCom`) apply here too - check it
    when the directory name is not an obvious slug of the display name.
 2. **Read the existing doc link.** `frontend/src/Utils/StaticData/tutorialLinks.js`
    maps a camelCase key to `{ youTubeLink, docLink }`. If `docLink` already
@@ -72,10 +72,10 @@ Verify first. Abort with the exact fix if missing.
    second one.
 3. **Collect the action event list** from
    `frontend/src/components/AllIntegrations/<Name>/staticData.js` (or
-   `<Name>Actions.jsx` / `options.js` in older integrations) — entries are
+   `<Name>Actions.jsx` / `options.js` in older integrations) - entries are
    `{ name, label, is_pro }`. The `label` strings are the exact event names;
    never invent or reword them. Note every `is_pro: true` event, but **never
-   append a `(PRO)` marker to an event label** — state the Pro requirement once
+   append a `(PRO)` marker to an event label**: state the Pro requirement once
    in prose, at the point where it matters.
 4. **Derive the authorization flow.** Read
    `frontend/src/components/AllIntegrations/<Name>/<Name>Authorization.jsx`:
@@ -84,7 +84,7 @@ Verify first. Abort with the exact fix if missing.
      `authDetails.authType` from `AUTH_TYPES` in
      `frontend/src/Utils/connectionAuth.js` (`wp_plugin_check`, `oauth2`,
      `oauth1`, `api_key`, `bearer_token`, `basic_auth`, `custom`), plus
-     `noteDetails.note` — quote that note.
+     `noteDetails.note`: quote that note.
    - Older integrations render bespoke inputs; read their labels and
      placeholders directly.
    Map the auth type to the sentences in [reference.md](reference.md).
@@ -99,7 +99,7 @@ Verify first. Abort with the exact fix if missing.
    mapped rather than typed. Read `RecordApiHelper.php` for which fields the API
    call actually requires.
 6. **Read the wizard shape** from
-   `frontend/src/components/AllIntegrations/<Name>/<Name>.jsx` — the
+   `frontend/src/components/AllIntegrations/<Name>/<Name>.jsx`: the
    `<Steps step={N} …/>` count tells you how many wizard steps the reader will
    see. The final screen is
    `frontend/src/components/AllIntegrations/IntegrationHelpers/IntegrationStepThree.jsx`:
@@ -107,11 +107,11 @@ Verify first. Abort with the exact fix if missing.
    the **Finish & Save ✔** button.
 7. **Collect trigger plugins for the use-case section** from the trigger
    registry `backend/Core/Util/AllTriggersName.php` (Pro triggers) and the free
-   triggers' own `{Key}Controller::info()` under `backend/Triggers/` — use real
+   triggers' own `{Key}Controller::info()` under `backend/Triggers/`: use real
    `name` values only (Bit Form, Contact Form 7, Gravity Forms, WPForms, Fluent
    Forms, Elementor, WooCommerce, LearnDash LMS, …).
    Choose each plugin by what the action event actually needs, not by
-   popularity — an event requiring `user_id` and `course_id` pairs with an LMS,
+   popularity - an event requiring `user_id` and `course_id` pairs with an LMS,
    not a contact form. See "Use-case realism" in [reference.md](reference.md)
    before writing any of them.
 8. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
@@ -119,7 +119,8 @@ Verify first. Abort with the exact fix if missing.
    overview paragraphs, the
    `How the <Platform> Action Works` and `Before You Start` H2 sections, the
    `How to Set Up ... in Bit Integrations` H2, sequential Title Case
-   `Step N: ...` H3 headings, the event accordion, the Step 5
+   `Step 01: ...` H3 headings, zero-padded to two digits, the event accordion,
+   the Step 05
    `Field | What to Set` table, and the `Explore <N> Useful ... Ideas` H2
    section.
    Apply the SEO and readability standards at the top of `reference.md` as you
@@ -137,43 +138,47 @@ Verify first. Abort with the exact fix if missing.
     titles, the trigger plugins named in the use-case section,
     internal/external links added, media IDs used, and the parent section id.
     Each use-case title is a link to its
-    `bit-integrations.com/triggers/<trigger-plugin>/connect/<platform>/` page —
+    `bit-integrations.com/triggers/<trigger-plugin>/connect/<platform>/` page -
     note the trigger plugin comes first even in an action doc. List those URLs
     in the preview with the `<title>` each one returned, because that site
     soft-404s and a `200` alone does not prove a page exists. See the
     "Use-case title link" section of `reference.md`.
     Include an **SEO/readability self-check** in the preview, confirming against
     the standards in `reference.md`. Report it in six groups:
-    - *Accuracy* — every action-event label, credential field and button text
+    - *Accuracy* - every action-event label, credential field and button text
       traced to a source file; no behavior borrowed from another platform;
       every `[VERIFY: …]` flag listed, especially platform-side navigation;
       Pro/plan gating stated where it matters; no `(PRO)` marker anywhere.
-    - *Use-case realism* — for **each** idea and each overview example, one line
+    - *Use-case realism* - for **each** idea and each overview example, one line
       naming the event's required fields and confirming the chosen trigger
       plugin can supply every one of them; no generic "submits a form, places an
       order, or registers" opener; no claimed outcome the helper does not
       produce (access granted, email sent, visitor experience changed). See
       "Use-case realism" in `reference.md`.
-    - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
+    - *SEO* - primary keyword in the H1, the first 100 words, an H2, the slug,
       the meta description and exactly one image alt; one H1, no skipped heading
       levels; link count; no duplicated content with the platform's trigger doc.
-    - *Extractability* — every heading answered in its first one or two
+    - *Extractability* - every heading answered in its first one or two
       sentences; no orphan pronouns; platform name repeated in each major
       section; specifics in tables not prose; no hedging words.
-    - *Readability* — paragraph and sentence length, active voice, second
+    - *Punctuation and step numbers* - zero em dashes and zero en dashes in
+      the whole doc, `<style>` block included (report both counts as `0`), and
+      every step heading zero-padded to two digits (`Step 01:`, `Step 02:`),
+      including any numbered sub-steps and any range named in prose.
+    - *Readability* - paragraph and sentence length, active voice, second
       person, every image alt filled and honest about what the shot contains, no
       banned words (`simply`, `just`, `easy`, `seamlessly`, …), every step
       imperative with an observable result.
-    - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
+    - *Block vocabulary* - the TL;DR group box, the warning callouts (list what
       each one warns about) and the use-case cards, with counts. No fourth block
       style, nothing boxed outside those three. Confirm each one carries its
       `bi-tldr`/`bi-warn`/`bi-card` class and **no inline colour**, and that the
-      `<style>` block is present as the first block of the content — inline
+      `<style>` block is present as the first block of the content - inline
       colours cannot express the site's dark mode.
-    - *Dark mode* — confirm the doc renders in **both** modes. After publishing,
+    - *Dark mode* - confirm the doc renders in **both** modes. After publishing,
       load the page, toggle `body_dark`, and check the computed contrast of every
       `td/th/p/li/a/h1-h4` against its composited background; report the count of
-      pairs under 4.5:1 in each mode. Markup alone does not prove this — a theme
+      pairs under 4.5:1 in each mode. Markup alone does not prove this - a theme
       `!important` rule can beat a correct-looking declaration.
     The whole doc is public-facing; get explicit approval on the title and the
     self-check before creating anything.
@@ -181,12 +186,12 @@ Verify first. Abort with the exact fix if missing.
     set its Gutenberg content. Set `ezd_doc_secondary_title` to the platform name
     as a **top-level** REST field through `wp/v2/docs/<id>` (a `meta.*` payload is
     ignored). Confirm the field exists in the authenticated `OPTIONS` schema
-    first — it is exposed by a site-specific snippet, not by EazyDocs Pro itself.
+    first - it is exposed by a site-specific snippet, not by EazyDocs Pro itself.
     Only when the field is absent from the schema, report the edit link and ask
     the user to set the EazyDocs Pro **Secondary Title** field manually, and do
     not report the sidebar-title work complete until the user confirms it was
     saved. Also report which placeholder screenshots need replacement, and every
-    `[VERIFY: …]` flag still in the body — the draft must not go public until
+    `[VERIFY: …]` flag still in the body - the draft must not go public until
     all of them are resolved and removed.
 13. **Set the Rank Math SEO fields** on the created doc automatically (no
     approval), via one authenticated
@@ -196,23 +201,23 @@ Verify first. Abort with the exact fix if missing.
     with:
     - `rank_math_focus_keyword`: 3-4 comma-separated keyword phrases derived from
       the doc (platform name + "integration" + the automation value), **most
-      important first** — the first phrase is the primary keyword Rank Math
+      important first**: the first phrase is the primary keyword Rank Math
       scores on. Example for Zoho CRM: `zoho crm integration, zoho crm bit
       integrations, zoho crm automation, form to crm`. (Multiple keywords need
       Rank Math Pro; on free only the first is used, which is why the primary
       must be first.)
     - `rank_math_description`: an AI-written meta description. **Do not open with
-      the post title or the phrase "<Platform> Integration as an Action"** —
+      the post title or the phrase "<Platform> Integration as an Action"** -
       start with the platform name early, then weave **semantic keywords** for
       the use case (connect, sync, automate, workflow, plus domain terms like
       "CRM contacts", "form submissions", "order data"). Mention Bit Integrations
       **once, briefly**, and include the primary focus keyword naturally so Rank
       Math scores it green.
-      **150-160 characters, hard ceiling 160 — never exceed it.** Count the
+      **150-160 characters, hard ceiling 160 - never exceed it.** Count the
       characters and trim to <=160 before sending.
     Write the keywords first, then compose the description to contain the primary
     keyword. If the `rankmath/v1/updateMeta` route returns 404, report it and
-    skip — do not fail the doc.
+    skip - do not fail the doc.
 14. **Offer the code follow-up.** After the draft is created, report the future
     public URL and offer to update the `docLink` for this platform in
     `frontend/src/Utils/StaticData/tutorialLinks.js`. Only edit the JS when the

--- a/.claude/skills/create-action-doc/SKILL.md
+++ b/.claude/skills/create-action-doc/SKILL.md
@@ -42,8 +42,10 @@ parent section post ID; read it from `DOC_ACTION_PARENT_POST_ID` in `.env`.
 Verify first. Abort with the exact fix if missing.
 
 1. `.env` at the plugin root contains `DOC_SITE_URL`, `DOC_SITE_USERNAME`,
-   `DOC_SITE_PASSWORD`, `DOC_ACTION_PARENT_POST_ID`, and
-   `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`. Copy `.env.example` to `.env` and fill
+   `DOC_SITE_PASSWORD`, `DOC_ACTION_PARENT_POST_ID`,
+   `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`,
+   `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`, and
+   `DOC_TRIGGER_LIST_ATTACHMENT_POST_ID`. Copy `.env.example` to `.env` and fill
    it if absent. Never print `DOC_SITE_PASSWORD`; HTTPS only.
 2. `DOC_SITE_PASSWORD` must be a WordPress **Application Password**, not the
    wp-admin login password.
@@ -72,8 +74,9 @@ Verify first. Abort with the exact fix if missing.
    `frontend/src/components/AllIntegrations/<Name>/staticData.js` (or
    `<Name>Actions.jsx` / `options.js` in older integrations) — entries are
    `{ name, label, is_pro }`. The `label` strings are the exact event names;
-   never invent or reword them. Note every `is_pro: true` event: it must be
-   marked `(PRO)` in the doc.
+   never invent or reword them. Note every `is_pro: true` event, but **never
+   append a `(PRO)` marker to an event label** — state the Pro requirement once
+   in prose, at the point where it matters.
 4. **Derive the authorization flow.** Read
    `frontend/src/components/AllIntegrations/<Name>/<Name>Authorization.jsx`:
    - Modern integrations render the shared
@@ -103,9 +106,14 @@ Verify first. Abort with the exact fix if missing.
    the **Conditional Logics** checkbox, the `Successfully Integrated` heading and
    the **Finish & Save ✔** button.
 7. **Collect trigger plugins for the use-case section** from the trigger
-   registry `backend/Core/Util/AllTriggersName.php` — use real `name` values
-   only (Bit Form, Contact Form 7, Gravity Forms, WPForms, Fluent Forms,
-   Elementor, WooCommerce, …).
+   registry `backend/Core/Util/AllTriggersName.php` (Pro triggers) and the free
+   triggers' own `{Key}Controller::info()` under `backend/Triggers/` — use real
+   `name` values only (Bit Form, Contact Form 7, Gravity Forms, WPForms, Fluent
+   Forms, Elementor, WooCommerce, LearnDash LMS, …).
+   Choose each plugin by what the action event actually needs, not by
+   popularity — an event requiring `user_id` and `course_id` pairs with an LMS,
+   not a contact form. See "Use-case realism" in [reference.md](reference.md)
+   before writing any of them.
 8. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
    secondary/sidebar title, in-content H1, the mandatory TL;DR paragraph,
    overview paragraphs, the
@@ -135,11 +143,17 @@ Verify first. Abort with the exact fix if missing.
     soft-404s and a `200` alone does not prove a page exists. See the
     "Use-case title link" section of `reference.md`.
     Include an **SEO/readability self-check** in the preview, confirming against
-    the standards in `reference.md`. Report it in four groups:
+    the standards in `reference.md`. Report it in six groups:
     - *Accuracy* — every action-event label, credential field and button text
       traced to a source file; no behavior borrowed from another platform;
       every `[VERIFY: …]` flag listed, especially platform-side navigation;
-      Pro/plan gating stated where it matters.
+      Pro/plan gating stated where it matters; no `(PRO)` marker anywhere.
+    - *Use-case realism* — for **each** idea and each overview example, one line
+      naming the event's required fields and confirming the chosen trigger
+      plugin can supply every one of them; no generic "submits a form, places an
+      order, or registers" opener; no claimed outcome the helper does not
+      produce (access granted, email sent, visitor experience changed). See
+      "Use-case realism" in `reference.md`.
     - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
       the meta description and exactly one image alt; one H1, no skipped heading
       levels; link count; no duplicated content with the platform's trigger doc.
@@ -147,8 +161,12 @@ Verify first. Abort with the exact fix if missing.
       sentences; no orphan pronouns; platform name repeated in each major
       section; specifics in tables not prose; no hedging words.
     - *Readability* — paragraph and sentence length, active voice, second
-      person, every image alt filled, no banned words (`simply`, `just`,
-      `easy`, `seamlessly`, …), every step imperative with an observable result.
+      person, every image alt filled and honest about what the shot contains, no
+      banned words (`simply`, `just`, `easy`, `seamlessly`, …), every step
+      imperative with an observable result.
+    - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
+      each one warns about) and the use-case cards, with counts. No fourth block
+      style, nothing boxed outside those three.
     The whole doc is public-facing; get explicit approval on the title and the
     self-check before creating anything.
 12. **Create a draft child doc** through EazyDocs using the full public title and

--- a/.claude/skills/create-action-doc/reference.md
+++ b/.claude/skills/create-action-doc/reference.md
@@ -258,8 +258,8 @@ paragraphs. It is the block a reader in a hurry acts on, and the block answer
 engines quote, so it carries the whole procedure in compressed form.
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fff5ef"},"spacing":{"padding":{"top":"18px","right":"20px","bottom":"18px","left":"20px"},"margin":{"bottom":"28px"}},"border":{"radius":"3px","left":{"color":"#f3a77f","width":"4px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#f3a77f;border-left-width:4px;background-color:#fff5ef;margin-bottom:28px;padding:18px 20px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as an action, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;credential&gt; from &lt;where it is created&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
+<!-- wp:group {"className":"bi-tldr","layout":{"type":"constrained"}} -->
+<div class="wp-block-group bi-tldr"><!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as an action, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;credential&gt; from &lt;where it is created&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 ```
 
@@ -717,19 +717,17 @@ These <N> barely scratch the surface. Bit Integrations connects 378+ apps to <Pl
 ## Block vocabulary — visual hierarchy
 
 Three styled block types, and no others. Every doc uses the same three so the
-Users Guide reads as one system. All colours are **inline**, because EazyDocs has
-no theme CSS behind custom classes; inline styles on `wp:group` survive the REST
-sanitiser, custom class names do not.
+Users Guide reads as one system.
 
 The rule that governs all three: **how loud a block may be depends on how many
 times the reader meets it.** A block seen once can shout. A block that repeats
 five times must whisper, or it becomes noise and drowns the one that matters.
 
-| Tier | Block | Times per doc | Left bar | Fill | Border |
-|---|---|---|---|---|---|
-| 1 | TL;DR | exactly 1 | `#f3a77f` 4px | `#fff5ef` | — |
-| 2 | Warning | 2-4 | `#d97757` 4px | `#fdf3f0` | — |
-| 3 | Use-case card | 4-5 | — | `#fdfcfb` | 1px `#e8e2dd` |
+| Tier | Block | Class | Times per doc |
+|---|---|---|---|
+| 1 | TL;DR | `bi-tldr` | exactly 1 |
+| 2 | Warning | `bi-warn` | 2-4 |
+| 3 | Use-case card | `bi-card` | 4-5 |
 
 Same shape, different colour, is what makes the vocabulary learnable. Do not
 invent a fourth style, and do not box anything outside these three.
@@ -738,72 +736,93 @@ invent a fourth style, and do not box anything outside these three.
 accordion. Tables already carry their own structure and steps are already
 delimited by their H3s, so boxing them tips the page into a wall of panels.
 
-### Inner margins — required on every styled block
+### Colours live in one `<style>` block, never in inline styles
 
-A styled group sets its own padding, and the theme also puts a bottom margin on
-the last `<p>` or `<ul>` inside it. The two stack, so the block renders with a
-visibly larger gap at the bottom than the top. Most themes use
-`margin: 0 0 1em`, which is why the defect shows up only at the bottom.
+The docs site has a **dark mode** (an `ezd_dark_switch` toggle that puts
+`body_dark` on `<body>`). An inline `style="background:#fff5ef"` cannot say
+"…and something else in dark mode", so a block styled inline becomes a glaring
+light slab on a near-black page — or, worse, keeps the theme's light text and
+turns invisible.
 
-Zero the inner margins explicitly — the group's padding is then the only
-spacing, and the box is symmetric:
+Inline styles also lose outright to the theme's `!important` rules:
 
-| Group contains | Fix |
-|---|---|
-| one paragraph (TL;DR, warning) | `margin-top:0;margin-bottom:0` on that paragraph |
-| several blocks (use-case card) | `margin-top:0` on the first block, `margin-bottom:0` on the last |
-
-Set it in **both** places, the block comment attribute and the inline `style`,
-or the editor and the front end disagree:
-
-```html
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0">TEXT</p><!-- /wp:paragraph -->
-
-<!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li>ITEM</li></ul><!-- /wp:list -->
+```css
+body.body_dark.single-docs #post p       { color:#eaeaea !important }   /* (1,2,2) */
+.doc-middle-content tr:nth-child(2n)     { color:#000    !important }   /* (0,2,1) */
+.body_dark.single-docs .wp-block-esab-accordion-child > .esab__active.esab__body
+                                         { background:#494949 !important } /* (0,5,0) */
 ```
 
-Never fix this by shrinking the group's bottom padding — that depends on the
-theme's font size and breaks the moment the theme changes.
+So: **put the class on the block, and put every colour in one `wp:html`
+`<style>` block at the top of the content.** A `<style>` block survives the REST
+write intact, `body_dark` selectors included, which is the only way to express a
+real dark variant. Verify with `context=edit` after writing.
 
-### Tier 2 — warning callout
-
-For the conditions that cost the reader a failed run. Place each one **before**
-the action it protects. Quote the exact error string from the helper when there
-is one — a reader who has already hit it will search for that text.
-
-Earns a warning:
-
-- a plan gate, on either side (`Bit Integrations Pro`, the platform's own Pro
-  tier, a third-party API tier)
-- an irreversible write — permanent delete, overwrite, "cannot be undone"
-- a precondition that makes the action fail — a record that must already exist,
-  a field that must already be populated
-
-Does not earn one: anything already obvious from the field table, or a mere
-preference.
+Emit the group with a `className` and **no** `style` attribute:
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fdf3f0"},"spacing":{"padding":{"top":"14px","right":"18px","bottom":"14px","left":"18px"},"margin":{"top":"18px","bottom":"18px"}},"border":{"radius":"3px","left":{"color":"#d97757","width":"4px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#d97757;border-left-width:4px;background-color:#fdf3f0;margin-top:18px;margin-bottom:18px;padding:14px 18px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>LEAD CONDITION.</strong> WHAT HAPPENS AND WHAT TO DO INSTEAD.</p><!-- /wp:paragraph --></div>
+<!-- wp:group {"className":"bi-tldr","layout":{"type":"constrained"}} -->
+<div class="wp-block-group bi-tldr"><!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> …</p><!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 ```
 
-State a gate **once**. If a warning callout covers a requirement, delete the
-duplicate sentences elsewhere — repeating the same fact three times reads as
-padding and pushes the real content down.
+Warnings use `bi-warn`, use-case cards use `bi-card`, with the card's linked
+bold title, rationale paragraph and Trigger/Action list inside. Padding and
+margins come from the stylesheet, so drop the old `margin-top:0`/`margin-bottom:0`
+zeroing attributes — they exist only to patch inline padding.
 
-### Tier 3 — use-case card
+### The stylesheet — paste verbatim as the first block of every doc
 
-Wraps each block in the use-case section: the linked bold title, the rationale
-paragraph, and the Trigger/Action list. Quietest treatment of the three, because
-it repeats.
+Selectors that must beat a theme `!important` rule carry the
+`body.body_dark.single-docs #post` prefix to clear its specificity. Do not
+shorten them.
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fdfcfb"},"spacing":{"padding":{"top":"20px","right":"22px","bottom":"20px","left":"22px"},"margin":{"top":"16px","bottom":"16px"}},"border":{"radius":"4px","color":"#e8e2dd","width":"1px"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-color:#e8e2dd;border-width:1px;border-radius:4px;background-color:#fdfcfb;margin-top:16px;margin-bottom:16px;padding:20px 22px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0">LINKED BOLD TITLE</p><!-- /wp:paragraph --><!-- wp:paragraph --><p class="wp-block-paragraph">RATIONALE</p><!-- /wp:paragraph --><!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li><strong>Trigger:</strong> …</li><li><strong>Action:</strong> …</li></ul><!-- /wp:list --></div>
-<!-- /wp:group -->
+<!-- wp:html --><style>
+/* ---- Bit Integrations doc blocks ---- */
+.bi-tldr{background:#fff5ef;color:#2b2119;border-left:4px solid #f3a77f;border-radius:3px;padding:18px 20px;margin:0 0 28px}
+.bi-warn{background:#fdf3f0;color:#2b2119;border-left:4px solid #d97757;border-radius:3px;padding:14px 18px;margin:18px 0}
+.bi-card{background:#fdfcfb;color:#2b2119;border:1px solid #e8e2dd;border-radius:4px;padding:20px 22px;margin:16px 0}
+.single-docs #post .bi-tldr p,.single-docs #post .bi-warn p,.single-docs #post .bi-card p,.single-docs #post .bi-card li{color:inherit!important}
+.single-docs #post .bi-card a{color:#6b21a8!important}
+body.body_dark .bi-tldr{background:#241c17;color:#f1e6dd;border-left-color:#f3a77f}
+body.body_dark .bi-warn{background:#2b1e19;color:#f7e0d6;border-left-color:#d97757}
+body.body_dark .bi-card{background:#1b1c21;color:#e7e2dd;border-color:#34363d}
+body.body_dark.single-docs #post .bi-tldr p,body.body_dark.single-docs #post .bi-warn p,body.body_dark.single-docs #post .bi-card p,body.body_dark.single-docs #post .bi-card li{color:inherit!important}
+body.body_dark.single-docs #post .bi-card a{color:#cbaef7!important}
+/* ---- tables follow the theme; only the hardcoded zebra fill is neutralised ---- */
+#post .wp-block-table table{background:transparent!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table th{background:rgba(127,127,127,.13)!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table td{background:transparent!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table tbody tr:nth-child(odd){background:transparent!important}
+#post .wp-block-table tbody tr:nth-child(even){background:rgba(127,127,127,.07)!important}
+/* the theme pairs its stripe with a forced black text colour; drop that too */
+#post .wp-block-table tbody tr:nth-child(even),#post .wp-block-table tbody tr:nth-child(even) td,#post .wp-block-table tbody tr:nth-child(even) th{color:inherit!important}
+/* the theme's brand link colour drops to 2:1 on the dark page */
+body.body_dark.single-docs #post p a,body.body_dark.single-docs #post li a{color:#cbaef7!important}
+/* ---- accordion ----
+   The head keeps the esab plugin's own purple: it ships that with !important at
+   a specificity we would have to fight, it is readable in both modes, and every
+   other doc on the site already looks that way. Only the body is ours. */
+.wp-block-esab-accordion .wp-block-esab-accordion-child{border:1px solid rgba(127,127,127,.3);border-radius:3px;overflow:hidden}
+body.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__body,body.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__active.esab__body{background:#fbfaf9!important;border-top:1px solid rgba(127,127,127,.28);padding:16px}
+body.body_dark.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__body,body.body_dark.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__active.esab__body{background:#1b1c21!important;border-top-color:rgba(127,127,127,.22)}
+</style><!-- /wp:html -->
 ```
 
+Why each table rule exists: the theme stripes even rows `#f7f7f7` **and** forces
+`color:#000` on them. Neutralising only the background leaves black text on a
+dark row; neutralising only the colour leaves a light row on a dark page. Both
+have to go, and the replacement stripe is a translucent grey so it reads
+correctly in either mode.
+
+### The accordion `blockStyle` attribute is decorative — never rely on it
+
+The esab accordion's `blockStyle` attribute is **not applied on the front end**
+of this site. A doc that puts its colours there ships unstyled: the head renders
+the plugin's default purple and the body takes the theme's dark `#494949`. Keep
+whatever `blockStyle` the snippet already carries, but never put a colour you
+depend on in it — those rules belong in the `<style>` block above.
 ### The existing note callout
 
 The site's `note_col` block still exists and renders an info icon above the

--- a/.claude/skills/create-action-doc/reference.md
+++ b/.claude/skills/create-action-doc/reference.md
@@ -6,10 +6,10 @@ known.
 **Canonical published example:**
 `https://bit-integrations.com/wp-docs/actions/bit-crm-integration-as-an-action/`
 (post ID `124666`). When this reference and that doc disagree, the published doc
-wins — fetch it with
+wins - fetch it with
 `curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs/124666?_fields=content"` and match it.
 
-## Writing standards — SEO and readability
+## Writing standards - SEO and readability
 
 These apply to the **entire document**, not just the title. Check them before
 sending the doc for approval.
@@ -32,16 +32,16 @@ sending the doc for approval.
 **Structure**
 
 - Exactly one H1. Never skip heading levels (H1 → H2 → H3 → H4).
-- Every heading is descriptive and front-loaded with the meaningful word — a
+- Every heading is descriptive and front-loaded with the meaningful word - a
   reader scanning only the headings must be able to follow the whole setup.
 - Answer-first: the first one or two sentences under **every** heading fully
   answer that heading. No warm-up, no "in this section we will look at".
 - Use tables and bulleted lists instead of walls of text; the event accordion,
-  the Step 5 field table, and the use-case bullets exist for this reason.
+  the Step 05 field table, and the use-case bullets exist for this reason.
 - This page is a **task doc**, not a tutorial or a concept page. It does not
   teach what an API key or OAuth is. Link out to the doc that does.
 
-**Accuracy — hard rules**
+**Accuracy - hard rules**
 
 Documentation errors cost more than SEO errors.
 
@@ -65,7 +65,7 @@ Documentation errors cost more than SEO errors.
   upsell inside a reference table. State plan gating once, in prose, where it
   changes what the reader does.
 - Never describe an outcome the code cannot produce. Before writing any example
-  or use case, read what the helper actually writes — see
+  or use case, read what the helper actually writes - see
   **Use-case realism** below.
 - If the platform's API cannot do what the keyword implies, say so plainly and
   early, then document the supported path.
@@ -73,10 +73,10 @@ Documentation errors cost more than SEO errors.
   of an action doc. Anything not read from source becomes an inline
   `[VERIFY: exact path to the API key screen in <Platform>]` flag in the draft
   **and** a line in the approval preview. Never quietly guess.
-  Every `[VERIFY: …]` must be resolved and removed before publishing — grep the
+  Every `[VERIFY: …]` must be resolved and removed before publishing - grep the
   content for `[VERIFY` as a release gate.
 
-**Extractability — how LLMs and answer engines read the page**
+**Extractability - how LLMs and answer engines read the page**
 
 - Every paragraph must survive being lifted out on its own. No orphan pronouns:
   "This mapping lets you…", not "This lets you…".
@@ -94,7 +94,7 @@ Documentation errors cost more than SEO errors.
 
 **Readability**
 
-- Second person, active voice, present tense. Short sentences — average under
+- Second person, active voice, present tense. Short sentences - average under
   20 words, split anything longer.
 - Paragraphs of three to four sentences at most.
 - Around a grade-8 reading level. Expand an acronym on first use.
@@ -108,7 +108,7 @@ Documentation errors cost more than SEO errors.
 **Banned language**
 
 - Never `simply`, `just`, `easy`, `obviously`, `of course`. They shame a reader
-  who is already stuck — and an action doc's reader is usually stuck on
+  who is already stuck - and an action doc's reader is usually stuck on
   credentials.
 - Never `seamlessly`, `effortlessly`, `revolutionary`, `game-changing`,
   `the possibilities are endless`, `let's dive in`, `in today's fast-paced
@@ -116,12 +116,25 @@ Documentation errors cost more than SEO errors.
 - Never promise a ranking, an AI citation or a rich snippet anywhere in the doc
   or in the report about it.
 
+**Punctuation**
+
+- **Never use an em dash (`-`) anywhere in the doc.** Not in prose, headings,
+  table cells, image alt text, the TL;DR, the meta description or a use-case
+  card. Rewrite instead: split the sentence at a full stop, use a colon before
+  an explanation, use a comma for an aside, or use brackets. Two short sentences
+  almost always beat one dash-joined sentence.
+- The en dash (`-`) is out too. Use a plain hyphen for ranges and compounds
+  (`150-160 characters`, `two-part model`).
+- Grep the finished Gutenberg HTML for the em dash and the en dash before the
+  approval preview; both counts must be `0`, including inside the `<style>`
+  block and any CSS comment that ships with it.
+
 **Links and images**
 
 - Two to four internal links to related docs on `bit-integrations.com`: the
   matching trigger doc for the same platform when it exists, the conditional
   logic doc, and one or two trigger-plugin docs named in the use-case section.
-  Anchor text must be descriptive and carry the destination's own keyword —
+  Anchor text must be descriptive and carry the destination's own keyword -
   never `click here`, never a bare URL.
 - Link once per destination per page. A second identical link adds nothing.
 - Link back to prerequisites and concepts, forward to the logical next task.
@@ -136,7 +149,7 @@ Documentation errors cost more than SEO errors.
   when the platform is visible; when the screenshot is a generic Bit Integrations
   screen that does not contain it, describe that screen honestly and add the
   platform only as context ("…, the first step of the `<Platform>` action
-  setup"). Never write an alt claiming a screenshot shows something it does not —
+  setup"). Never write an alt claiming a screenshot shows something it does not -
   including a state that is not captured, such as "with a plugin chosen" on a
   shot where nothing is selected.
 - Open every screenshot before writing its alt or placing it. The file name and
@@ -209,23 +222,26 @@ exists before creating a new one:
 curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs?parent=$DOC_ACTION_PARENT_POST_ID&search=<Platform>&_fields=id,slug,title"
 ```
 
-Also check the exact slug is free (`wp/v2/docs?slug=...`) — WordPress silently
+Also check the exact slug is free (`wp/v2/docs?slug=...`) - WordPress silently
 renames a duplicate to `...-2`. If it is taken, stop and confirm with the user.
 
 When posting the title to the EazyDocs `create-child` endpoint, replace `&` with
 `ezd_ampersand`, `#` with `ezd_hash`, and `+` with `ezd_plus`; that endpoint
 decodes them back via `decode_special_chars`. Send the title/slug **raw**
-(unencoded) to the core `wp/v2/docs/<id>` endpoint — it does not decode these
+(unencoded) to the core `wp/v2/docs/<id>` endpoint - it does not decode these
 tokens, so an encoded title would be stored literally.
 
 ## Document structure
 
-The content opens with an H1 that repeats the post title — published action docs
+The content opens with an H1 that repeats the post title - published action docs
 on this site keep the H1 inside the content, so match that. H2 for sections, H3
 for steps, H4 for event categories inside the accordion.
 
-Step headings use **Title Case** and no leading zero: `Step 3: Authorize Zoho
-CRM`, not `Step 03: authorize zoho crm`.
+Step headings use **Title Case** and a **two-digit number**, zero-padded:
+`Step 01: Authorize Zoho CRM`, not `Step 01: Authorize Zoho CRM` and not `Step 01: authorize zoho crm`.
+Pad every step from `01` to `09`; `10` and beyond are already two digits.
+Numbered sub-steps inside a step follow the same rule (`01.`, `02.`), and
+prose that refers to a range uses the padded form too (`Steps 01-03`).
 
 ```text
 <h1>  <Platform> Integration as an Action
@@ -235,23 +251,23 @@ CRM`, not `Step 03: authorize zoho crm`.
 <h2>  Before You Start
 <h2>  How to Set Up <Platform> Integration as an Action in Bit Integrations
       <one paragraph: how many steps, work through them in order>
-<h3>    Step 1: Create the Integration and Set Up Your Trigger
-<h3>    Step 2: Search and Select <Platform> as the Action
-<h3>    Step 3: Authorize <Platform>
-<h3>    Step 4: Choose Your <Platform> Action Event
-<h3>    Step 5: Configure the Action Fields
-<h3>    Step 6: Map Your Fields and Finish
+<h3>    Step 01: Create the Integration and Set Up Your Trigger
+<h3>    Step 02: Search and Select <Platform> as the Action
+<h3>    Step 03: Authorize <Platform>
+<h3>    Step 04: Choose Your <Platform> Action Event
+<h3>    Step 05: Configure the Action Fields
+<h3>    Step 06: Map Your Fields and Finish
 <h2>  Explore <N> Useful <Platform> Integration as an Action Ideas
 ```
 
 When the platform needs credentials created on its own site and that takes more
 than two clicks, promote it to its own step placed before `Authorize`:
-`Step 2: Create Your <Platform> API Token`, with numbered H3 sub-steps
+`Step 02: Create Your <Platform> API Token`, with numbered H3 sub-steps
 (`1. Open Account Settings`, `2. Open API Access Tokens`, …), then renumber the
 remaining steps. This matches the published Sender doc
 (`sender-integration-as-an-action`).
 
-### TL;DR — mandatory, always first
+### TL;DR - mandatory, always first
 
 One paragraph, placed immediately after the H1 and before the overview
 paragraphs. It is the block a reader in a hurry acts on, and the block answer
@@ -267,15 +283,15 @@ Rules:
 
 - Two to four sentences. Never more.
 - It must work **alone**. An experienced reader acts on the TL;DR and never
-  scrolls further, so a path that only makes sense after reading Step 3 has
+  scrolls further, so a path that only makes sense after reading Step 03 has
   failed.
 - Name the real UI labels and a real action-event label, bolded, under the same
-  accuracy rules as the rest of the page — **Create Integration**,
+  accuracy rules as the rest of the page - **Create Integration**,
   **Authorize**, **Finish & Save**, and one event copied verbatim from
   `staticData.js`.
 - **Name the credential the reader must fetch, and where it comes from.** This
   is the single thing an action-doc reader most needs up front, and the reason
-  they bounce when it is buried in Step 3.
+  they bounce when it is buried in Step 03.
 - Contain the primary keyword naturally. This is inside the first 100 words, so
   it satisfies that placement requirement.
 - State the prerequisites in the same breath, including
@@ -286,7 +302,7 @@ Rules:
 - Adjust the path per auth type: an OAuth platform's TL;DR says click
   **Authorize** and approve access, an API-key platform's says paste the key.
 
-### Overview — 2-3 paragraphs
+### Overview - 2-3 paragraphs
 
 ```text
 <Paragraph 1: what the platform manages or does, then one line: with Bit Integrations you can automatically send data from your WordPress website to <Platform>.>
@@ -294,12 +310,12 @@ Rules:
 For example, when <one concrete actor does one concrete thing>, Bit Integrations can <real event label from staticData.js> in <Platform> <with the static config that event needs>. When <a second, different concrete scenario>, it can <a second real event label>. <One line on what nobody has to do by hand any more.>
 ```
 
-The example paragraph is subject to **Use-case realism** below — the same rules
+The example paragraph is subject to **Use-case realism** below - the same rules
 that govern the ideas section. In particular:
 
 - **Never write "when someone submits a form, places an order, or registers as a
   user".** That sentence fits every platform, which is exactly why it is worthless
-  — it describes no real workflow and pairs generic triggers with whatever events
+  because it describes no real workflow and pairs generic triggers with whatever events
   happen to exist.
 - Pick the two scenarios by reading the required fields of the events you name.
   An event taking `user_id` and `course_id` gets an LMS scenario, not a contact
@@ -314,7 +330,7 @@ jargon.
 One paragraph, a two-item list, then one closing paragraph:
 
 ```text
-Every integration in Bit Integrations has two halves. The trigger is what starts the workflow. The action is what happens as a result. When <Platform> is the action, <plain-language statement of where the platform sits — e.g. "your CRM sits at the receiving end">.
+Every integration in Bit Integrations has two halves. The trigger is what starts the workflow. The action is what happens as a result. When <Platform> is the action, <plain-language statement of where the platform sits - e.g. "your CRM sits at the receiving end">.
 
 - Trigger: an event in another app, such as <3 trigger events that genuinely suit this platform, each naming its plugin>.
 - Action: a <Platform> operation, such as <3-4 real event labels from staticData.js>.
@@ -322,7 +338,7 @@ Every integration in Bit Integrations has two halves. The trigger is what starts
 Bit Integrations catches the incoming data; you decide which incoming field belongs in which <Platform> field, and from that point on, the record is created for you every single time. <For same-site WordPress plugins, add: Everything runs on your own WordPress install.>
 ```
 
-The three trigger examples in that list must suit **this** platform — a video
+The three trigger examples in that list must suit **this** platform - a video
 plugin gets a video submission, an LMS lesson completion and an opt-in; a CRM
 gets a checkout, a signup and a support request. Do not reuse one generic trio
 across docs.
@@ -352,24 +368,24 @@ sub-steps.
 
 - **One action per step.** If the body needs "and then", it is two steps.
 - Open each step with an imperative verb the reader can act on: Click, Open,
-  Select, Enter, Enable, Copy, Paste. Never "Configure as needed" — a step you
+  Select, Enter, Enable, Copy, Paste. Never "Configure as needed" - a step you
   cannot describe concretely is not a step.
 - Name the exact UI element and its exact label, in the real path form:
   **Bit Integrations → Create Integration**. For platform-side navigation, give
   the real menu path on the platform's own site.
 - **State the observable result**, so the reader can confirm they are on track:
   "The connection is saved and the action event list loads." Never end a step on
-  a click. This matters most after **Authorize** — say what a successful
+  a click. This matters most after **Authorize**: say what a successful
   connection looks like, and what an expired or read-only credential looks like.
 - Put a warning **before** the action it protects, never after.
 - When a step branches by auth type or plan tier, give each branch its own
   labelled sentence or bullet rather than nested "if … otherwise" prose.
 - The closing paragraph must contain a concrete success check the reader can
-  see — run the trigger once, then which screen in the platform to open and what
-  record should appear there — not just "you are done".
+  see - run the trigger once, then which screen in the platform to open and what
+  record should appear there - not just "you are done".
 - Keep the count realistic. Past about ten steps, group them into phases.
 
-### Step 1: Create the Integration and Set Up Your Trigger
+### Step 01: Create the Integration and Set Up Your Trigger
 
 This step uses **two fixed screenshots**, not placeholders. Both are the same on
 every action doc, so they come from `.env` and are embedded as real images:
@@ -381,7 +397,7 @@ every action doc, so they come from `.env` and are embedded as real images:
 
 Split the prose so each image sits under the sentence it illustrates. Do not
 put both images at the end of the step, and do not use
-`{{PLACEHOLDER:select-trigger}}` here — that slot no longer exists.
+`{{PLACEHOLDER:select-trigger}}` here - that slot no longer exists.
 
 ```text
 From your WordPress dashboard, open Bit Integrations and click Create Integration.
@@ -397,14 +413,14 @@ Complete the trigger setup for that plugin, which usually means picking the spec
 
 `Please select a Trigger` and `Search Trigger...` are the real strings
 (`frontend/src/components/Flow/New/SelectTrigger.jsx`), matching the
-`Please select an Action` label used in Step 2.
+`Please select an Action` label used in Step 02.
 
 Resolve both IDs through `GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>` and embed
 `source_url` with the real-image block. Alt text must describe what is actually
-in the frame — neither screenshot contains the platform, so do not write an alt
+in the frame - neither screenshot contains the platform, so do not write an alt
 claiming it does.
 
-### Step 2: Search and Select `<Platform>` as the Action
+### Step 02: Search and Select `<Platform>` as the Action
 
 ```text
 On the "Please select an Action" screen, type <Platform> into the search box and click the <Platform> card when it appears.
@@ -415,7 +431,7 @@ On the "Please select an Action" screen, type <Platform> into the search box and
 
 Then `{{PLACEHOLDER:select-action-app}}`.
 
-### Step 3: Authorize `<Platform>`
+### Step 03: Authorize `<Platform>`
 
 Open with the integration-name sentence, which is the same for every platform:
 
@@ -428,9 +444,9 @@ Give the integration a name so you can recognise it later in your integrations l
 
 Then, depending on `authDetails.authType`:
 
-- **`wp_plugin_check`** — no connection form. Use the canonical wording:
+- **`wp_plugin_check`**: no connection form. Use the canonical wording:
   `Bit Integrations detects the active <Platform> plugin and authorizes it instantly. There is nothing to copy, paste, or configure. Once the authorization succeeds, click Next.`
-- **everything else** — in this order:
+- **everything else**: in this order:
   1. Explain the **Connections** dropdown: reuse an existing connection, or click
      **+ Add new connection**. Reusing saves time and avoids duplicates.
   2. The auth-type **Add Connection** sentence from the table below.
@@ -452,10 +468,10 @@ real UI strings from `frontend/src/components/Connections/`.
 | `api_key` | `Click + Add new connection. You will be asked for a Connection Name and your <Platform> API Key.` | `Once your <Platform> API Key is entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
 | `bearer_token` | `Click + Add new connection. You will be asked for a Connection Name and your <Platform> Bearer Token.` | `Once your <Platform> Bearer Token is entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
 | `basic_auth` | `Click + Add new connection. You will be asked for a Connection Name plus the Username and Password of your <Platform> account.` | `Once your <Platform> Username and Password are entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
-| `oauth2` | `Click + Add new connection. You will be asked for a Connection Name, your Client ID, and your Client Secret. Copy the Callback / Redirect URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize — a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
-| `oauth1` | `Click + Add new connection. You will be asked for a Connection Name, your Consumer Key, and your Consumer Secret. Copy the Callback / Return URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize — a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
-| `wp_plugin_check` | *(no connection form — see Step 3 above)* | `If the check passes, click Next to continue. If it fails, install or activate <Platform> and try again.` |
-| `custom` | Derive from the bespoke fields in `<Name>Authorization.jsx` — list every input label in the order it appears. | `Once every field above is filled in, click Authorize to continue.` |
+| `oauth2` | `Click + Add new connection. You will be asked for a Connection Name, your Client ID, and your Client Secret. Copy the Callback / Redirect URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize - a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
+| `oauth1` | `Click + Add new connection. You will be asked for a Connection Name, your Consumer Key, and your Consumer Secret. Copy the Callback / Return URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize - a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
+| `wp_plugin_check` | *(no connection form - see Step 03 above)* | `If the check passes, click Next to continue. If it fails, install or activate <Platform> and try again.` |
+| `custom` | Derive from the bespoke fields in `<Name>Authorization.jsx`: list every input label in the order it appears. | `Once every field above is filled in, click Authorize to continue.` |
 
 For `oauth2` / `oauth1`, this app model is self-service: the user registers their
 own app on the platform and pastes the client/consumer credentials.
@@ -479,16 +495,16 @@ Source priority:
    contradicted.
 2. General knowledge fills gaps with plausible settings-navigation steps.
 
-**Flag these steps in the approval preview** — platform UIs change and the
+**Flag these steps in the approval preview**: platform UIs change and the
 source text is usually thin.
 
-### Step 4: Choose Your `<Platform>` Action Event
+### Step 04: Choose Your `<Platform>` Action Event
 
 ```text
 Open the Action dropdown and pick the operation you want <Platform> to perform. All <N> supported actions are in this list, grouped by module.
 ```
 
-`<N>` is the event count computed from `staticData.js` — never a guessed number.
+`<N>` is the event count computed from `staticData.js`: never a guessed number.
 
 Then the event accordion (below), then:
 
@@ -515,7 +531,7 @@ two-column table:
 | Column | Content |
 |---|---|
 | `Action Event` | The exact `label` string from `staticData.js`, bolded. Nothing appended |
-| `What It Does` | One or two sentences, grounded in `RecordApiHelper.php` — which endpoint it hits and what it needs mapped |
+| `What It Does` | One or two sentences, grounded in `RecordApiHelper.php`: which endpoint it hits and what it needs mapped |
 
 Example row from the canonical doc:
 
@@ -523,7 +539,7 @@ Example row from the canonical doc:
 > from your trigger app.
 
 Never reword an event label. When the integration has fewer than about eight
-events, one ungrouped table without H4s is fine — the published Sender doc does
+events, one ungrouped table without H4s is fine - the published Sender doc does
 that.
 
 **Never append a `(PRO)` marker to an event label**, in this table or anywhere
@@ -533,7 +549,7 @@ State plan gating once, in prose, where it changes what the reader does:
 `Bit Integrations Pro` in `Before You Start`, and a third-party plan
 requirement as its own sentence at the step where the reader picks the event.
 
-### Step 5: Configure the Action Fields
+### Step 05: Configure the Action Fields
 
 ```text
 Now set the static values that apply to every record this integration creates. Using <First Event Label> as the example, you will see the following options.
@@ -549,14 +565,14 @@ in render order:
 
 Mark required fields as required. Then `{{PLACEHOLDER:configure-action}}`.
 
-### Step 6: Map Your Fields and Finish
+### Step 06: Map Your Fields and Finish
 
 ```text
 This is the step that does the real work. The Field Map screen shows two columns. On the left are the fields coming from your trigger plugin, with sample values from your test submission shown in brackets. On the right are the <Platform> fields.
 
 Pair them up. <Real field name> goes to <Real field name>, and so on. Use the plus button to add another mapping row and the trash icon to remove one you do not need. Use Custom Value when you want to send a fixed value instead of a trigger field.
 
-Turn on Conditional Logics at the bottom of the screen if you only want this action to run some of the time — for example, only create a record when a specific field meets your condition.
+Turn on Conditional Logics at the bottom of the screen if you only want this action to run some of the time - for example, only create a record when a specific field meets your condition.
 
 When the mapping looks right, click Next, then Finish & Save ✔ to save the integration. Bit Integrations confirms with Successfully Integrated. Run the trigger once for real and check <Platform> to confirm the record appeared exactly as you expected.
 ```
@@ -564,7 +580,7 @@ When the mapping looks right, click Next, then Finish & Save ✔ to save the int
 `Map Fields`, `Conditional Logics`, `Next`, `Finish & Save ✔` and
 `Successfully Integrated` are the real UI strings
 (`IntegrationHelpers/IntegrationStepThree.jsx`). The published Bit CRM doc says
-"click Next to finish and save" — use the real button name instead.
+"click Next to finish and save" - use the real button name instead.
 
 Then `{{PLACEHOLDER:map-fields}}`. Add `{{PLACEHOLDER:integration-log}}` and one
 sentence about the integration timeline when the doc should cover logs.
@@ -577,7 +593,7 @@ sentence about the integration timeline when the doc should cover logs.
 Each of these uses the same <N>-step setup described above, with a different trigger plugin at the front.
 ```
 
-Then one block per idea — the title is a **bold linked paragraph**, not a
+Then one block per idea - the title is a **bold linked paragraph**, not a
 heading:
 
 ```text
@@ -601,7 +617,7 @@ Use four or five ideas. Trigger plugin names must come from
 `backend/Core/Util/AllTriggersName.php` or a free trigger's
 `{Name}Controller::info()`; the operations named must come from `staticData.js`.
 
-### Use-case realism — hard rules
+### Use-case realism - hard rules
 
 Every idea must be an automation a real site owner would actually build. This is
 the section most likely to go wrong, because generic pairings read fine and are
@@ -613,7 +629,7 @@ in the Pro helper *before* choosing a trigger. The fields name the caller:
 
 | Required fields on the event | What that implies |
 |---|---|
-| `user_id`, `course_id`, `step_id` | an LMS trigger — a lesson or course event |
+| `user_id`, `course_id`, `step_id` | an LMS trigger - a lesson or course event |
 | an email plus a record identifier | an opt-in or registration form |
 | a record ID the reader must already know | a form where a human types that ID, or an edit/admin flow |
 | only free text | an intake form, submitted by a person |
@@ -631,18 +647,18 @@ then describe exactly that and nothing more. Recurring traps:
 
 **Every field the action needs must be obtainable from that trigger.** If the
 event requires a record ID and the trigger is a public form, the use case has to
-say the submitter supplies that ID — or pick a different trigger. Never leave a
+say the submitter supplies that ID - or pick a different trigger. Never leave a
 required field unaccounted for.
 
 **Banned opener.** Do not write "when someone submits a form, places an order, or
-registers as a user" — or any variant that lists generic triggers and staples
+registers as a user" - or any variant that lists generic triggers and staples
 them to whatever events exist. Name one concrete actor doing one concrete thing:
 a contributor, an editor, a student, a customer.
 
 **State the manual work removed.** One clause naming what the reader stops doing
 by hand is what makes a use case useful rather than decorative.
 
-**Name the real gotcha** when the event has one — a plan requirement, a field
+**Name the real gotcha** when the event has one - a plan requirement, a field
 that must already exist, an irreversible write. A use case that hides the
 condition sends the reader into a failed run.
 
@@ -669,12 +685,12 @@ Example: `https://bit-integrations.com/triggers/gravity-forms/connect/sender/`
 
 **The trigger plugin is always the first slot and this platform is always the
 second**, even though this is an action doc. The connect pages only exist under
-`/triggers/…/connect/…`. There is no `/actions/<platform>/connect/<x>/` route —
+`/triggers/…/connect/…`. There is no `/actions/<platform>/connect/<x>/` route -
 it soft-404s. `/actions/<platform>/` and `/integrations/<platform>/` also
 resolve but serve an unrelated page, so never link to either.
 
 Both slugs belong to the marketing site and are **not derived** from anything in
-this repo — not the doc slug, not the `AllTriggersName.php` key, not the
+this repo - not the doc slug, not the `AllTriggersName.php` key, not the
 `integs` `type` value. Observed mismatches:
 
 | Source value | Connect slug |
@@ -692,7 +708,7 @@ this repo — not the doc slug, not the `AllTriggersName.php` key, not the
 
 Verify **positively**. A live connect page's title matches
 `<Platform> Integration with <Trigger Plugin> - Automate Your Tasks`. Do not
-test for a specific 404 string — the site serves at least two of them
+test for a specific 404 string - the site serves at least two of them
 (`Page not found` and `Page Not Found - Bit Integrations`), so a match against
 one of those will pass a dead URL through.
 
@@ -714,7 +730,7 @@ Close with one wrap-up paragraph:
 These <N> barely scratch the surface. Bit Integrations connects 378+ apps to <Platform>, including <6-8 real trigger plugin names>. The setup process is the same every time.
 ```
 
-## Block vocabulary — visual hierarchy
+## Block vocabulary - visual hierarchy
 
 Three styled block types, and no others. Every doc uses the same three so the
 Users Guide reads as one system.
@@ -741,7 +757,7 @@ delimited by their H3s, so boxing them tips the page into a wall of panels.
 The docs site has a **dark mode** (an `ezd_dark_switch` toggle that puts
 `body_dark` on `<body>`). An inline `style="background:#fff5ef"` cannot say
 "…and something else in dark mode", so a block styled inline becomes a glaring
-light slab on a near-black page — or, worse, keeps the theme's light text and
+light slab on a near-black page - or, worse, keeps the theme's light text and
 turns invisible.
 
 Inline styles also lose outright to the theme's `!important` rules:
@@ -769,9 +785,9 @@ Emit the group with a `className` and **no** `style` attribute:
 Warnings use `bi-warn`, use-case cards use `bi-card`, with the card's linked
 bold title, rationale paragraph and Trigger/Action list inside. Padding and
 margins come from the stylesheet, so drop the old `margin-top:0`/`margin-bottom:0`
-zeroing attributes — they exist only to patch inline padding.
+zeroing attributes - they exist only to patch inline padding.
 
-### The stylesheet — paste verbatim as the first block of every doc
+### The stylesheet - paste verbatim as the first block of every doc
 
 Selectors that must beat a theme `!important` rule carry the
 `body.body_dark.single-docs #post` prefix to clear its specificity. Do not
@@ -816,18 +832,18 @@ dark row; neutralising only the colour leaves a light row on a dark page. Both
 have to go, and the replacement stripe is a translucent grey so it reads
 correctly in either mode.
 
-### The accordion `blockStyle` attribute is decorative — never rely on it
+### The accordion `blockStyle` attribute is decorative - never rely on it
 
 The esab accordion's `blockStyle` attribute is **not applied on the front end**
 of this site. A doc that puts its colours there ships unstyled: the head renders
 the plugin's default purple and the body takes the theme's dark `#494949`. Keep
 whatever `blockStyle` the snippet already carries, but never put a colour you
-depend on in it — those rules belong in the `<style>` block above.
+depend on in it - those rules belong in the `<style>` block above.
 ### The existing note callout
 
 The site's `note_col` block still exists and renders an info icon above the
 literal word **Note**. Use it only for genuine asides. Never use it for the
-TL;DR — it would label the primary path as an aside — and never for a warning,
+TL;DR - it would label the primary path as an aside - and never for a warning,
 which needs its own colour.
 
 After setting content, verify the blocks survived by refetching with
@@ -900,12 +916,12 @@ names.
 
 Every `{{PLACEHOLDER:<slot>}}` resolves from
 `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`; only alt text and caption change. Alt text
-must follow the site's style — a plain sentence describing the shot. The alts
+must follow the site's style - a plain sentence describing the shot. The alts
 below are the ones used in the canonical Bit CRM doc, with the platform
 substituted.
 
-Step 1 has no placeholder slot — it uses the two fixed screenshots from `.env`
-described in the Step 1 section above.
+Step 01 has no placeholder slot - it uses the two fixed screenshots from `.env`
+described in the Step 01 section above.
 
 | Slot | Alt text |
 |---|---|
@@ -973,7 +989,7 @@ curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
 ```
 
 `ezd_doc_secondary_title` is exposed as a REST **field** on the `docs` post type
-(via `register_rest_field`) by a site-specific code snippet — EazyDocs Pro's own
+(via `register_rest_field`) by a site-specific code snippet - EazyDocs Pro's own
 build does not register it; the `docs` CPT's `supports` array omits
 `custom-fields`, so a plain `register_post_meta()` would silently fail to surface
 at all. Send it as a **top-level** key, not nested under `meta`; a

--- a/.claude/skills/create-action-doc/reference.md
+++ b/.claude/skills/create-action-doc/reference.md
@@ -1,0 +1,745 @@
+# create-action-doc reference
+
+Load only after the platform, its auth type, and its action event list are
+known.
+
+**Canonical published example:**
+`https://bit-integrations.com/wp-docs/actions/bit-crm-integration-as-an-action/`
+(post ID `124666`). When this reference and that doc disagree, the published doc
+wins — fetch it with
+`curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs/124666?_fields=content"` and match it.
+
+## Writing standards — SEO and readability
+
+These apply to the **entire document**, not just the title. Check them before
+sending the doc for approval.
+
+**Keywords**
+
+- Primary keyword: `<Platform> integration`. It must appear in the H1, in the
+  **first paragraph within the first 100 words**, in at least one H2, in the
+  slug, in the meta description, and in at least one image alt.
+- Secondary keywords to weave in naturally across the body:
+  `<Platform> Bit Integrations`, `<Platform> automation`,
+  `WordPress <Platform> integration`, plus the domain terms the platform owns
+  (`CRM contacts`, `subscribers`, `order data`, `form submissions`).
+- Natural density only. Never repeat the exact phrase in consecutive sentences,
+  never keyword-stuff a heading, never write a sentence whose only job is to
+  hold a keyword.
+- The action doc and the trigger doc for the same platform must not duplicate
+  each other. Different intros, different examples, different use cases.
+
+**Structure**
+
+- Exactly one H1. Never skip heading levels (H1 → H2 → H3 → H4).
+- Every heading is descriptive and front-loaded with the meaningful word — a
+  reader scanning only the headings must be able to follow the whole setup.
+- Answer-first: the first one or two sentences under **every** heading fully
+  answer that heading. No warm-up, no "in this section we will look at".
+- Use tables and bulleted lists instead of walls of text; the event accordion,
+  the Step 5 field table, and the use-case bullets exist for this reason.
+- This page is a **task doc**, not a tutorial or a concept page. It does not
+  teach what an API key or OAuth is. Link out to the doc that does.
+
+**Accuracy — hard rules**
+
+Documentation errors cost more than SEO errors.
+
+- Never invent a feature, action event, field, credential name, scope, menu
+  path, limit, plan tier or trigger plugin. If it is not in the source, it does
+  not go in the doc.
+- Source-of-truth order: the action's `{Name}Controller.php` /
+  `RecordApiHelper.php` → `AllIntegrations/{Name}/staticData.js` and
+  `{Name}Authorization.jsx` → `SelectAction.jsx` → the platform's own official
+  API docs. Nothing else. Not memory, not a similar integration, not a
+  competitor.
+- Reproduce action-event labels, credential field labels and button text
+  **character for character** as the code emits them. Never reword, never fix
+  their casing.
+- Never mix platforms. A Sender doc contains only Sender behavior.
+- State a Pro-only or plan-gated requirement at the point where it matters, not
+  only in Before You Start. This includes third-party plan limits, such as an
+  API that is unavailable on the platform's free tier.
+- If the platform's API cannot do what the keyword implies, say so plainly and
+  early, then document the supported path.
+- Platform-side navigation to a credential screen is the most error-prone part
+  of an action doc. Anything not read from source becomes an inline
+  `[VERIFY: exact path to the API key screen in <Platform>]` flag in the draft
+  **and** a line in the approval preview. Never quietly guess.
+  Every `[VERIFY: …]` must be resolved and removed before publishing — grep the
+  content for `[VERIFY` as a release gate.
+
+**Extractability — how LLMs and answer engines read the page**
+
+- Every paragraph must survive being lifted out on its own. No orphan pronouns:
+  "This mapping lets you…", not "This lets you…".
+- Repeat the full platform name in each major section. Retrieval pulls
+  fragments, not whole pages, so a section that only says "the platform" is
+  unattributable.
+- Give an extractable one-sentence definition where a term matters: "Field
+  mapping in Bit Integrations is the step where each trigger field is matched to
+  a <Platform> field."
+- Credentials, scopes, limits, formats and prerequisites belong in a list or
+  table, never woven into prose.
+- No hedging. "May", "might", "possibly", "generally", "should normally" destroy
+  citation value. State the fact, or state its condition: "On the free plan, the
+  API returns a 403."
+
+**Readability**
+
+- Second person, active voice, present tense. Short sentences — average under
+  20 words, split anything longer.
+- Paragraphs of three to four sentences at most.
+- Around a grade-8 reading level. Expand an acronym on first use.
+- No unexplained jargon, no internal code names, no class or method names in the
+  public body.
+- Bold the real UI labels the reader must find on screen (`Create Integration`,
+  `Integration Name`, `Authorize`, `Map Fields`, `Finish & Save`). Bold is for
+  UI labels and warnings only, never for general emphasis.
+- Lead with the condition, not the consequence: "If your key is read-only, …".
+
+**Banned language**
+
+- Never `simply`, `just`, `easy`, `obviously`, `of course`. They shame a reader
+  who is already stuck — and an action doc's reader is usually stuck on
+  credentials.
+- Never `seamlessly`, `effortlessly`, `revolutionary`, `game-changing`,
+  `the possibilities are endless`, `let's dive in`, `in today's fast-paced
+  world`, `it's important to note that`.
+- Never promise a ranking, an AI citation or a rich snippet anywhere in the doc
+  or in the report about it.
+
+**Links and images**
+
+- Two to four internal links to related docs on `bit-integrations.com`: the
+  matching trigger doc for the same platform when it exists, the conditional
+  logic doc, and one or two trigger-plugin docs named in the use-case section.
+  Anchor text must be descriptive and carry the destination's own keyword —
+  never `click here`, never a bare URL.
+- Link once per destination per page. A second identical link adds nothing.
+- Link back to prerequisites and concepts, forward to the logical next task.
+- One external link to the platform's own site or API docs where credentials are
+  created, when the auth type needs them.
+- Name the hub or parent page that will link **in** to this doc in the approval
+  preview. For action docs that is the `Actions` section
+  (`DOC_ACTION_PARENT_POST_ID`), so no doc ships orphaned.
+- Every image needs descriptive alt text containing the platform name, stating
+  what the shot shows and where it is. No empty alts, no filename alts.
+- Put the primary keyword in exactly one alt, and only where it reads
+  accurately. Do not repeat it across every alt.
+- Never let a step exist only inside a screenshot. The instruction must be in
+  the text; the image only confirms it. This matters most for credential steps,
+  where the reader is copying a value between two browser tabs.
+
+**Meta**
+
+- Meta description 150-160 characters, hard ceiling 160, containing the primary
+  keyword and not opening with the post title.
+
+## Post title, sidebar title, and slug
+
+EazyDocs Pro supports a separate sidebar label through the **Secondary Title**
+field (`ezd_doc_secondary_title`). The WordPress/EazyDocs post title must be the
+full public document title; never shorten `post_title` just to change the
+sidebar.
+
+**WordPress/EazyDocs post title:**
+
+```text
+<Platform> Integration as an Action
+```
+
+Examples: `Bit CRM Integration as an Action`,
+`Sender Integration as an Action`. Use the exact `type` value from the `integs`
+array in `frontend/src/components/Flow/New/SelectAction.jsx`. Use singular
+`Integration`, never `Integrations`.
+
+> **Note:** The post title must be SEO-friendly and user-friendly. Include the
+> exact platform name, use natural language, and avoid keyword stuffing, vague
+> claims, or awkward repetition.
+
+**EazyDocs Pro Secondary Title / sidebar label:**
+
+```text
+<Platform>
+```
+
+Examples: `Bit CRM`, `Sender`, `Zoho CRM`. Save this value in
+`ezd_doc_secondary_title`. EazyDocs' left-sidebar walker reads it and falls back
+to `post_title` only when empty.
+
+**URL slug, fixed for action docs:**
+
+```text
+<platform-slug>-integration-as-an-action
+```
+
+Examples: `bit-crm-integration-as-an-action`,
+`sender-integration-as-an-action`. Always singular `-integration-`, and always
+the full `-as-an-action` suffix. Trigger docs use the short
+`<platform-slug>-integration`, so the two doc types never collide.
+
+| Doc type | Slug |
+|---|---|
+| Trigger | `<platform-slug>-integration` |
+| Action | `<platform-slug>-integration-as-an-action` |
+
+Older docs on the site use legacy slugs (`<platform>-integrations`). Do not copy
+those for new docs, but do check whether a legacy doc for this platform already
+exists before creating a new one:
+
+```bash
+curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs?parent=$DOC_ACTION_PARENT_POST_ID&search=<Platform>&_fields=id,slug,title"
+```
+
+Also check the exact slug is free (`wp/v2/docs?slug=...`) — WordPress silently
+renames a duplicate to `...-2`. If it is taken, stop and confirm with the user.
+
+When posting the title to the EazyDocs `create-child` endpoint, replace `&` with
+`ezd_ampersand`, `#` with `ezd_hash`, and `+` with `ezd_plus`; that endpoint
+decodes them back via `decode_special_chars`. Send the title/slug **raw**
+(unencoded) to the core `wp/v2/docs/<id>` endpoint — it does not decode these
+tokens, so an encoded title would be stored literally.
+
+## Document structure
+
+The content opens with an H1 that repeats the post title — published action docs
+on this site keep the H1 inside the content, so match that. H2 for sections, H3
+for steps, H4 for event categories inside the accordion.
+
+Step headings use **Title Case** and no leading zero: `Step 3: Authorize Zoho
+CRM`, not `Step 03: authorize zoho crm`.
+
+```text
+<h1>  <Platform> Integration as an Action
+      <TL;DR paragraph>
+      <2-3 overview paragraphs>
+<h2>  How the <Platform> Action Works
+<h2>  Before You Start
+<h2>  How to Set Up <Platform> Integration as an Action in Bit Integrations
+      <one paragraph: how many steps, work through them in order>
+<h3>    Step 1: Create the Integration and Set Up Your Trigger
+<h3>    Step 2: Search and Select <Platform> as the Action
+<h3>    Step 3: Authorize <Platform>
+<h3>    Step 4: Choose Your <Platform> Action Event
+<h3>    Step 5: Configure the Action Fields
+<h3>    Step 6: Map Your Fields and Finish
+<h2>  Explore <N> Useful <Platform> Integration as an Action Ideas
+```
+
+When the platform needs credentials created on its own site and that takes more
+than two clicks, promote it to its own step placed before `Authorize`:
+`Step 2: Create Your <Platform> API Token`, with numbered H3 sub-steps
+(`1. Open Account Settings`, `2. Open API Access Tokens`, …), then renumber the
+remaining steps. This matches the published Sender doc
+(`sender-integration-as-an-action`).
+
+### TL;DR — mandatory, always first
+
+One paragraph, placed immediately after the H1 and before the overview
+paragraphs. It is the block a reader in a hurry acts on, and the block answer
+engines quote, so it carries the whole procedure in compressed form.
+
+```html
+<!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as an action, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;credential&gt; from &lt;where it is created&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph -->
+```
+
+Rules:
+
+- Two to four sentences. Never more.
+- It must work **alone**. An experienced reader acts on the TL;DR and never
+  scrolls further, so a path that only makes sense after reading Step 3 has
+  failed.
+- Name the real UI labels and a real action-event label, bolded, under the same
+  accuracy rules as the rest of the page — **Create Integration**,
+  **Authorize**, **Finish & Save**, and one event copied verbatim from
+  `staticData.js`.
+- **Name the credential the reader must fetch, and where it comes from.** This
+  is the single thing an action-doc reader most needs up front, and the reason
+  they bounce when it is buried in Step 3.
+- Contain the primary keyword naturally. This is inside the first 100 words, so
+  it satisfies that placement requirement.
+- State the prerequisites in the same breath, including
+  `Bit Integrations Pro` when the action is Pro-only, and any third-party plan
+  tier the API requires.
+- Give a time estimate only when the step count supports one. Do not invent a
+  number to fill the sentence.
+- Adjust the path per auth type: an OAuth platform's TL;DR says click
+  **Authorize** and approve access, an API-key platform's says paste the key.
+
+### Overview — 2-3 paragraphs
+
+```text
+<Paragraph 1: what the platform manages or does, then one line: with Bit Integrations you can automatically send data from your WordPress website to <Platform>.>
+
+For example, when someone submits a form, places an order, registers for an event, or completes another action on your site, Bit Integrations can <do the platform's main operation, using a real event label from staticData.js> without any manual data entry.
+```
+
+Human-written, simple, customer-friendly. No stiff marketing copy, no developer
+jargon.
+
+### How the `<Platform>` Action Works
+
+One paragraph, a two-item list, then one closing paragraph:
+
+```text
+Every integration in Bit Integrations has two halves. The trigger is what starts the workflow. The action is what happens as a result. When <Platform> is the action, <plain-language statement of where the platform sits — e.g. "your CRM sits at the receiving end">.
+
+- Trigger: an event in another app, such as a Contact Form 7 submission, a WooCommerce order, or a new user registration.
+- Action: a <Platform> operation, such as <3-4 real event labels from staticData.js>.
+
+Bit Integrations catches the incoming data; you decide which incoming field belongs in which <Platform> field, and from that point on, the record is created for you every single time. <For same-site WordPress plugins, add: Everything runs on your own WordPress install.>
+```
+
+### Before You Start
+
+A short bullet list of real prerequisites only:
+
+```text
+- Bit Integrations is installed and activated on your WordPress site.
+- <Platform> is installed and activated on the same site.   <- only for AUTH_TYPES.WP_PLUGIN_CHECK integrations; use the exact sentence from noteDetails.note when present
+- The trigger plugin you want to use, for example, Contact Form 7 or WooCommerce, is installed and has at least one form or product ready.
+- A <Platform> account with <the credential the connection needs, named with the UI label>.   <- for API/OAuth integrations
+- Bit Integrations Pro is active.   <- only when any staticData.js event is is_pro: true
+```
+
+### Setup section lead-in
+
+```text
+<N> steps from a blank workflow to a live automation. Work through them in order, because each screen depends on the one before it.
+```
+
+### Step craft rules
+
+These apply to every `Step N:` heading, including the numbered credential
+sub-steps.
+
+- **One action per step.** If the body needs "and then", it is two steps.
+- Open each step with an imperative verb the reader can act on: Click, Open,
+  Select, Enter, Enable, Copy, Paste. Never "Configure as needed" — a step you
+  cannot describe concretely is not a step.
+- Name the exact UI element and its exact label, in the real path form:
+  **Bit Integrations → Create Integration**. For platform-side navigation, give
+  the real menu path on the platform's own site.
+- **State the observable result**, so the reader can confirm they are on track:
+  "The connection is saved and the action event list loads." Never end a step on
+  a click. This matters most after **Authorize** — say what a successful
+  connection looks like, and what an expired or read-only credential looks like.
+- Put a warning **before** the action it protects, never after.
+- When a step branches by auth type or plan tier, give each branch its own
+  labelled sentence or bullet rather than nested "if … otherwise" prose.
+- The closing paragraph must contain a concrete success check the reader can
+  see — run the trigger once, then which screen in the platform to open and what
+  record should appear there — not just "you are done".
+- Keep the count realistic. Past about ten steps, group them into phases.
+
+### Step 1: Create the Integration and Set Up Your Trigger
+
+```text
+From your WordPress dashboard, open Bit Integrations and click Create Integration. On the trigger selection screen, search for the plugin you want to pull data from and select it. Contact Form 7 is a good first choice for a test run.
+
+Complete the trigger setup for that plugin, which usually means picking the specific form and running a test submission so Bit Integrations can read the field structure. Once that is done, you land on the action selection screen.
+```
+
+Then `{{PLACEHOLDER:select-trigger}}`.
+
+### Step 2: Search and Select `<Platform>` as the Action
+
+```text
+On the "Please select an Action" screen, type <Platform> into the search box and click the <Platform> card when it appears.
+```
+
+`Please select an Action` is the real screen heading
+(`frontend/src/components/Flow/New/SelectAction.jsx`).
+
+Then `{{PLACEHOLDER:select-action-app}}`.
+
+### Step 3: Authorize `<Platform>`
+
+Open with the integration-name sentence, which is the same for every platform:
+
+```text
+Give the integration a name so you can recognise it later in your integrations list, then click Authorize.
+```
+
+`Integration Name:` and `Authorize` are the real labels
+(`frontend/src/components/Connections/`).
+
+Then, depending on `authDetails.authType`:
+
+- **`wp_plugin_check`** — no connection form. Use the canonical wording:
+  `Bit Integrations detects the active <Platform> plugin and authorizes it instantly. There is nothing to copy, paste, or configure. Once the authorization succeeds, click Next.`
+- **everything else** — in this order:
+  1. Explain the **Connections** dropdown: reuse an existing connection, or click
+     **+ Add new connection**. Reusing saves time and avoids duplicates.
+  2. The auth-type **Add Connection** sentence from the table below.
+  3. `{{PLACEHOLDER:add-connection-form}}`.
+  4. The credential retrieval lead-in and numbered steps (below).
+  5. `{{PLACEHOLDER:credential-source}}`.
+  6. The auth-type **Authorize** sentence from the table below.
+
+Then `{{PLACEHOLDER:authorized}}`.
+
+## Auth-type templates
+
+Read the auth type from `authDetails.authType` in `<Name>Authorization.jsx`
+(values in `frontend/src/Utils/connectionAuth.js`). Field labels below are the
+real UI strings from `frontend/src/components/Connections/`.
+
+| `authType` | Add Connection sentence | Authorize sentence |
+|---|---|---|
+| `api_key` | `Click + Add new connection. You will be asked for a Connection Name and your <Platform> API Key.` | `Once your <Platform> API Key is entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
+| `bearer_token` | `Click + Add new connection. You will be asked for a Connection Name and your <Platform> Bearer Token.` | `Once your <Platform> Bearer Token is entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
+| `basic_auth` | `Click + Add new connection. You will be asked for a Connection Name plus the Username and Password of your <Platform> account.` | `Once your <Platform> Username and Password are entered, click Authorize. The button turns into Authorized ✔ when the credentials check out.` |
+| `oauth2` | `Click + Add new connection. You will be asked for a Connection Name, your Client ID, and your Client Secret. Copy the Callback / Redirect URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize — a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
+| `oauth1` | `Click + Add new connection. You will be asked for a Connection Name, your Consumer Key, and your Consumer Secret. Copy the Callback / Return URL shown in the form and paste it into your <Platform> app before you save it there.` | `Click Authorize — a <Platform> window opens asking you to approve access. Approve it, and you are returned to Bit Integrations with the connection marked Authorized ✔.` |
+| `wp_plugin_check` | *(no connection form — see Step 3 above)* | `If the check passes, click Next to continue. If it fails, install or activate <Platform> and try again.` |
+| `custom` | Derive from the bespoke fields in `<Name>Authorization.jsx` — list every input label in the order it appears. | `Once every field above is filled in, click Authorize to continue.` |
+
+For `oauth2` / `oauth1`, this app model is self-service: the user registers their
+own app on the platform and pastes the client/consumer credentials.
+
+## Credential steps
+
+Lead-in, bolded:
+
+```text
+To set up the <Platform> integration with Bit Integrations, you will need your <credential name(s) exactly as labelled in the UI>. Follow these steps to get them.
+```
+
+Then a numbered list of concrete UI-navigation steps on the platform's own site.
+
+Source priority:
+
+1. Facts from the integration's own note/helper text (`noteDetails.note`,
+   placeholders, helper strings in `<Name>Authorization.jsx`, and any
+   `documentation`/`docs` URL in the controller). URLs, product names, menu
+   names, and credential locations must appear unchanged and must not be
+   contradicted.
+2. General knowledge fills gaps with plausible settings-navigation steps.
+
+**Flag these steps in the approval preview** — platform UIs change and the
+source text is usually thin.
+
+### Step 4: Choose Your `<Platform>` Action Event
+
+```text
+Open the Action dropdown and pick the operation you want <Platform> to perform. All <N> supported actions are in this list, grouped by module.
+```
+
+`<N>` is the event count computed from `staticData.js` — never a guessed number.
+
+Then the event accordion (below), then:
+
+```text
+Common choices to start with:
+
+- <Event Label> for <why someone would pick it>.
+- <Event Label> for <why>.
+- <Event Label> for <why>.
+```
+
+Then `{{PLACEHOLDER:choose-event}}`.
+
+### Event accordion
+
+Collapsed by default, headed
+`See all available <Platform> action events in Bit Integrations`.
+
+Inside it, group events into categories derived from the `name` prefixes in
+`staticData.js`, each an `<h4>` named `<Module> Actions` (`Lead Actions`,
+`Contact Actions`, `Deal Actions`, `Invoice Actions`, …), followed by one
+two-column table:
+
+| Column | Content |
+|---|---|
+| `Action Event` | The exact `label` string from `staticData.js`, bolded. Append ` (PRO)` when `is_pro: true` |
+| `What It Does` | One or two sentences, grounded in `RecordApiHelper.php` — which endpoint it hits and what it needs mapped |
+
+Example row from the canonical doc:
+
+> **Create Lead** | Adds a brand new lead to Bit CRM using the data that came
+> from your trigger app.
+
+Never reword an event label. When the integration has fewer than about eight
+events, one ungrouped table without H4s is fine — the published Sender doc does
+that.
+
+### Step 5: Configure the Action Fields
+
+```text
+Now set the static values that apply to every record this integration creates. Using <First Event Label> as the example, you will see the following options.
+```
+
+Then a two-column table, one row per field rendered by `<Name>IntegLayout.jsx`,
+in render order:
+
+| Column | Content |
+|---|---|
+| `Field` | The exact field label from the UI |
+| `What to Set` | What it is, where its options come from, and what to pick. Spell out dropdown options when the list is fixed (`Available options are Mr, Mrs, Miss, Ms, and Dr.`); say the list is pulled from the platform when it is fetched live |
+
+Mark required fields as required. Then `{{PLACEHOLDER:configure-action}}`.
+
+### Step 6: Map Your Fields and Finish
+
+```text
+This is the step that does the real work. The Field Map screen shows two columns. On the left are the fields coming from your trigger plugin, with sample values from your test submission shown in brackets. On the right are the <Platform> fields.
+
+Pair them up. <Real field name> goes to <Real field name>, and so on. Use the plus button to add another mapping row and the trash icon to remove one you do not need. Use Custom Value when you want to send a fixed value instead of a trigger field.
+
+Turn on Conditional Logics at the bottom of the screen if you only want this action to run some of the time — for example, only create a record when a specific field meets your condition.
+
+When the mapping looks right, click Next, then Finish & Save ✔ to save the integration. Bit Integrations confirms with Successfully Integrated. Run the trigger once for real and check <Platform> to confirm the record appeared exactly as you expected.
+```
+
+`Map Fields`, `Conditional Logics`, `Next`, `Finish & Save ✔` and
+`Successfully Integrated` are the real UI strings
+(`IntegrationHelpers/IntegrationStepThree.jsx`). The published Bit CRM doc says
+"click Next to finish and save" — use the real button name instead.
+
+Then `{{PLACEHOLDER:map-fields}}`. Add `{{PLACEHOLDER:integration-log}}` and one
+sentence about the integration timeline when the doc should cover logs.
+
+## Use-case section
+
+`<h2>` `Explore <N> Useful <Platform> Integration as an Action Ideas`, then:
+
+```text
+Each of these uses the same <N>-step setup described above, with a different trigger plugin at the front.
+```
+
+Then one block per idea — the title is a **bold linked paragraph**, not a
+heading:
+
+```text
+**<Trigger Plugin> <Platform> Integration**   <- the whole title is a link
+```
+
+```html
+<!-- wp:paragraph --><p class="wp-block-paragraph"><a href="CONNECT_URL"><strong>&lt;Trigger Plugin&gt; &lt;Platform&gt; Integration</strong></a></p><!-- /wp:paragraph -->
+```
+
+Then the body of the block:
+
+```text
+<One short paragraph of rationale: why this automation matters, in human terms.>
+
+- Trigger: <what happens in the trigger plugin>
+- Action: <real action event label(s) from staticData.js>
+```
+
+Use four or five ideas. Trigger plugin names must come from
+`backend/Core/Util/AllTriggersName.php`; the operations named must come from
+`staticData.js`.
+
+### Use-case title link
+
+Each title links to the marketing-site connect page for that exact pairing:
+
+```text
+https://bit-integrations.com/triggers/<trigger-plugin-connect-slug>/connect/<platform-connect-slug>/
+```
+
+Example: `https://bit-integrations.com/triggers/gravity-forms/connect/sender/`
+
+**The trigger plugin is always the first slot and this platform is always the
+second**, even though this is an action doc. The connect pages only exist under
+`/triggers/…/connect/…`. There is no `/actions/<platform>/connect/<x>/` route —
+it soft-404s. `/actions/<platform>/` and `/integrations/<platform>/` also
+resolve but serve an unrelated page, so never link to either.
+
+Both slugs belong to the marketing site and are **not derived** from anything in
+this repo — not the doc slug, not the `AllTriggersName.php` key, not the
+`integs` `type` value. Observed mismatches:
+
+| Source value | Connect slug |
+|---|---|
+| `Mail Chimp` | `mailchimp` |
+| `Fluent CRM` | `fluentcrm` |
+| `Google Sheet` | `google-sheets` |
+| `FluentPlayer` | `fluent-player` |
+| `Contact Form 7` | `contact-form-7` |
+
+**Verify every one of these links before the approval preview.**
+`bit-integrations.com` soft-404s: a missing connect page still answers HTTP
+`200` with a full-size body, so a status-code check proves nothing. The
+`<title>` is the only reliable signal.
+
+Verify **positively**. A live connect page's title matches
+`<Platform> Integration with <Trigger Plugin> - Automate Your Tasks`. Do not
+test for a specific 404 string — the site serves at least two of them
+(`Page not found` and `Page Not Found - Bit Integrations`), so a match against
+one of those will pass a dead URL through.
+
+```bash
+curl -sL "https://bit-integrations.com/triggers/<trigger-plugin>/connect/<platform>/" \
+  | grep -o '<title>[^<]*</title>'
+# accept only if it reads "<Platform> Integration with <Trigger Plugin> - Automate Your Tasks"
+```
+
+Start from the trigger plugin's own index,
+`https://bit-integrations.com/triggers/<trigger-plugin-connect-slug>/`, to find
+which pairings exist. If a pairing has no live connect page, choose a different
+trigger plugin for that idea rather than shipping a dead link. Report the
+verified URLs in the approval preview.
+
+Close with one wrap-up paragraph:
+
+```text
+These <N> barely scratch the surface. Bit Integrations connects 378+ apps to <Platform>, including <6-8 real trigger plugin names>. The setup process is the same every time.
+```
+
+## Gutenberg snippets
+
+For the accordion, generate unique IDs per doc, such as `esab-abc1234` and
+`esab-child123`, then replace every `ACCORDION_ID` and `ACCORDION_CHILD_ID`
+placeholder consistently in the block comment, CSS selectors, and HTML class
+names.
+
+```html
+<!-- headings, paragraphs, lists -->
+<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">TEXT</h1><!-- /wp:heading -->
+<!-- wp:heading --><h2 class="wp-block-heading">TEXT</h2><!-- /wp:heading -->
+<!-- wp:heading {"level":3} --><h3 class="wp-block-heading">TEXT</h3><!-- /wp:heading -->
+<!-- wp:heading {"level":4} --><h4 class="wp-block-heading">TEXT</h4><!-- /wp:heading -->
+<!-- wp:paragraph --><p class="wp-block-paragraph">TEXT</p><!-- /wp:paragraph -->
+<!-- wp:list --><ul class="wp-block-list"><li>ITEM</li></ul><!-- /wp:list -->
+
+<!-- two-column event table -->
+<!-- wp:table {"hasFixedLayout":true} -->
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th><strong>Action Event</strong></th><th><strong>What It Does</strong></th></tr></thead><tbody><tr><td><strong>EVENT LABEL</strong></td><td>WHAT IT DOES</td></tr></tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- step 5 configuration table -->
+<!-- wp:table {"hasFixedLayout":true} -->
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th><strong>Field</strong></th><th><strong>What to Set</strong></th></tr></thead><tbody><tr><td><strong>FIELD LABEL</strong></td><td>WHAT TO SET</td></tr></tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- styled available-events accordion; use this instead of wp:details -->
+<!-- wp:esab/accordion {"uniqueId":"ACCORDION_ID","blockStyle":" .ACCORDION_ID.wp-block-esab-accordion, .ACCORDION_ID.wp-block-esab-accordion.nested-accordion{margin:0 0 30px 0;} .ACCORDION_ID.wp-block-esab-accordion > .esab__container{gap:10px;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child{border-style:solid;border-color:#f3a77f;border-width:1px;border-radius:3px;overflow:hidden;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child > .esab__head{background:#ffc0a6;padding:14px 10px;gap:8px;} .ACCORDION_ID.wp-block-esab-accordion .esab__heading_tag{color:#263a55;font-weight:700;margin:0;} .ACCORDION_ID.wp-block-esab-accordion .esab__icon svg{fill:#111111;width:20px;height:20px;} .ACCORDION_ID.wp-block-esab-accordion .esab__icon svg path{fill:#111111;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child > .esab__body{border-top:1px solid #f3a77f;padding:16px;background:#ffffff;} ","allowAllClose":true} -->
+<div class="wp-block-esab-accordion ACCORDION_ID" data-mode="global" data-close="true"><div class="esab__container"><!-- wp:esab/accordion-child {"uniqueId":"ACCORDION_CHILD_ID","blockStyle":" .ACCORDION_CHILD_ID.wp-block-esab-accordion-child .esab__badge{border-style: solid;} ","heading":"<strong>See all available PLATFORM action events in Bit Integrations</strong>","headingTag":"p","collapsedIcon":"esab__circle_plus","expandedIcon":"esab__circle_minus"} -->
+<div class="wp-block-esab-accordion-child"><div class="esab__head" role="button" aria-expanded="false"><div class="esab__heading_txt"><p class="esab__heading_tag"><strong>See all available PLATFORM action events in Bit Integrations</strong></p></div><div class="esab__icon"><div class="esab__collapse"> <svg version="1.2" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="m3.5 20.5c-4.7-4.7-4.7-12.3 0-17 4.7-4.7 12.3-4.7 17 0 4.6 4.7 4.6 12.3 0 17-4.7 4.6-12.3 4.6-17 0zm0.9-0.9c4.2 4.2 11 4.2 15.2 0 4.2-4.2 4.2-11 0-15.2-4.2-4.3-11-4.3-15.2 0-4.3 4.2-4.3 11 0 15.2z"></path><path d="m11.4 15.9v-3.3h-3.3c-0.3 0-0.6-0.3-0.6-0.6 0-0.4 0.3-0.6 0.6-0.6h3.3v-3.3c0-0.3 0.3-0.6 0.6-0.6 0.3 0 0.6 0.3 0.6 0.6v3.3h3.3c0.3 0 0.6 0.2 0.6 0.6q0 0.2-0.2 0.4-0.2 0.2-0.4 0.2h-3.3v3.3q0 0.2-0.2 0.4-0.2 0.2-0.4 0.2c-0.4 0-0.6-0.3-0.6-0.6z"></path></svg> </div><div class="esab__expand"> <svg version="1.2" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="m12 24c-6.6 0-12-5.4-12-12 0-6.6 5.4-12 12-12 6.6 0 12 5.4 12 12 0 6.6-5.4 12-12 12zm10.6-12c0-5.9-4.7-10.6-10.6-10.6-5.9 0-10.6 4.7-10.6 10.6 0 5.9 4.7 10.6 10.6 10.6 5.9 0 10.6-4.7 10.6-10.6z"></path><path d="m5.6 11.3h12.8v1.4h-12.8z"></path></svg> </div></div></div><div class="esab__body">H4 CATEGORY HEADINGS + EVENT TABLES GO HERE</div></div>
+<!-- /wp:esab/accordion-child --></div></div>
+<!-- /wp:esab/accordion -->
+
+<!-- note / info callout -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"className":"note_col"} -->
+<div class="wp-block-column note_col"><!-- wp:freeform -->
+<p><img class="alignnone size-full wp-image-4353" src="https://bitapps.pro/wp-content/uploads/2023/06/info-icon.png" alt="note-icon-bit-apps" width="24" height="24" />  <strong>Note</strong></p>
+<!-- /wp:freeform -->
+
+<!-- wp:paragraph -->
+<p>NOTE TEXT</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- placeholder screenshot -->
+<!-- wp:image {"align":"center","size":"large"} -->
+<figure class="wp-block-image aligncenter size-large">
+  <img src="PLACEHOLDER_SOURCE_URL" alt="TODO: screenshot of SLOT_DESCRIPTION"/>
+  <figcaption>Replace with a real screenshot: SLOT_DESCRIPTION</figcaption>
+</figure>
+<!-- /wp:image -->
+
+<!-- real fixed image -->
+<!-- wp:image {"id":MEDIA_ID,"align":"center","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large">
+  <img src="SOURCE_URL" alt="ALT" class="wp-image-MEDIA_ID"/>
+</figure>
+<!-- /wp:image -->
+```
+
+## Placeholder image slots
+
+Every `{{PLACEHOLDER:<slot>}}` resolves from
+`DOC_PLACEHOLDER_ATTACHMENT_POST_ID`; only alt text and caption change. Alt text
+must follow the site's style — a plain sentence describing the shot. The alts
+below are the ones used in the canonical Bit CRM doc, with the platform
+substituted.
+
+| Slot | Alt text |
+|---|---|
+| `select-trigger` | `Choose a trigger plugin` |
+| `select-action-app` | `Search and select <Platform> as an action` |
+| `add-connection-form` | `Add a <Platform> connection in Bit Integrations` |
+| `credential-source` | `<Platform> settings page where the credential is copied from` |
+| `authorized` | `Click on <Platform> Authorize button` |
+| `choose-event` | `Choose specific <Platform> action event` |
+| `configure-action` | `Configure the integration` |
+| `field-<id>` | `<Field Label> field filled in, in the <Platform> action settings` |
+| `map-fields` | `Map the fields between trigger fields with <Platform> fields` |
+| `integration-log` | `<Platform> integration timeline and logs` |
+
+Resolve `DOC_PLACEHOLDER_ATTACHMENT_POST_ID` through
+`GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>` and embed its `source_url`. Do not
+upload or cache these images.
+
+## Media and EazyDocs API
+
+Read credentials, the parent section post ID, and media IDs from `.env`:
+`DOC_SITE_URL`, `DOC_SITE_USERNAME`, `DOC_SITE_PASSWORD`,
+`DOC_ACTION_PARENT_POST_ID`, `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`.
+`DOC_SITE_PASSWORD` must be a WordPress Application Password. Never print it.
+
+Resolve an attachment:
+
+```bash
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  "$DOC_SITE_URL/wp-json/wp/v2/media/<media-id>"
+```
+
+Create the draft child. The title here must already have `&`/`#`/`+` replaced
+with `ezd_ampersand`/`ezd_hash`/`ezd_plus`:
+
+```bash
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  -H "Content-Type: application/json" \
+  -d '{"parent_id":<DOC_ACTION_PARENT_POST_ID>,"title":"<encoded title>","post_status":"draft"}' \
+  "$DOC_SITE_URL/wp-json/eazydocs/v1/docs-builder/create-child"
+```
+
+Set content. The Gutenberg HTML is full of quotes, so never inline it in
+`-d '...'`; write the JSON body to a temp file in the scratchpad directory
+(title/slug **raw** here, not token-encoded) and send that:
+
+```bash
+# build body.json first, e.g. with jq --rawfile for the content field
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  -H "Content-Type: application/json" \
+  --data @body.json \
+  "$DOC_SITE_URL/wp-json/wp/v2/docs/<id>"
+```
+
+`body.json`:
+
+```json
+{
+  "slug": "<platform-slug>-integration-as-an-action",
+  "title": "<Platform> Integration as an Action",
+  "ezd_doc_secondary_title": "<Platform>",
+  "content": "<gutenberg html beginning with the h1>"
+}
+```
+
+`ezd_doc_secondary_title` is exposed as a REST **field** on the `docs` post type
+(via `register_rest_field`) by a site-specific code snippet — EazyDocs Pro's own
+build does not register it; the `docs` CPT's `supports` array omits
+`custom-fields`, so a plain `register_post_meta()` would silently fail to surface
+at all. Send it as a **top-level** key, not nested under `meta`; a
+`{"meta": {...}}` payload is silently ignored. Confirm the field exists first by
+inspecting the authenticated `OPTIONS` schema for `wp/v2/docs/<id>`.
+
+After the update, fetch the doc with `context=edit` and verify:
+
+- `title.raw` equals the full public title.
+- `slug` equals the intended slug (not `...-2`).
+- `ezd_doc_secondary_title` equals `<Platform>`.
+
+Only when the field is absent from the `OPTIONS` schema, fall back to manual
+entry: return the draft edit link and ask the user to open it, find the EazyDocs
+Pro **Secondary Title** panel, set its **Title** field to `<Platform>`, and save
+the draft. Wait for confirmation, then verify the sidebar label before reporting
+completion.

--- a/.claude/skills/create-action-doc/reference.md
+++ b/.claude/skills/create-action-doc/reference.md
@@ -60,6 +60,13 @@ Documentation errors cost more than SEO errors.
 - State a Pro-only or plan-gated requirement at the point where it matters, not
   only in Before You Start. This includes third-party plan limits, such as an
   API that is unavailable on the platform's free tier.
+- **Never append a `(PRO)` marker** to an event label, feature name or table row.
+  A marker on every row carries no information; a marker on some rows reads as an
+  upsell inside a reference table. State plan gating once, in prose, where it
+  changes what the reader does.
+- Never describe an outcome the code cannot produce. Before writing any example
+  or use case, read what the helper actually writes — see
+  **Use-case realism** below.
 - If the platform's API cannot do what the keyword implies, say so plainly and
   early, then document the supported path.
 - Platform-side navigation to a credential screen is the most error-prone part
@@ -123,8 +130,18 @@ Documentation errors cost more than SEO errors.
 - Name the hub or parent page that will link **in** to this doc in the approval
   preview. For action docs that is the `Actions` section
   (`DOC_ACTION_PARENT_POST_ID`), so no doc ships orphaned.
-- Every image needs descriptive alt text containing the platform name, stating
-  what the shot shows and where it is. No empty alts, no filename alts.
+- Every image needs descriptive alt text stating what the shot shows and where
+  it is. No empty alts, no filename alts.
+- **The alt must describe what is actually in the frame.** Name the platform
+  when the platform is visible; when the screenshot is a generic Bit Integrations
+  screen that does not contain it, describe that screen honestly and add the
+  platform only as context ("…, the first step of the `<Platform>` action
+  setup"). Never write an alt claiming a screenshot shows something it does not —
+  including a state that is not captured, such as "with a plugin chosen" on a
+  shot where nothing is selected.
+- Open every screenshot before writing its alt or placing it. The file name and
+  the attachment title are not reliable descriptions, and an image placed under
+  the wrong sentence is worse than a placeholder.
 - Put the primary keyword in exactly one alt, and only where it reads
   accurately. Do not repeat it across every alt.
 - Never let a step exist only inside a screenshot. The instruction must be in
@@ -241,7 +258,9 @@ paragraphs. It is the block a reader in a hurry acts on, and the block answer
 engines quote, so it carries the whole procedure in compressed form.
 
 ```html
-<!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as an action, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;credential&gt; from &lt;where it is created&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph -->
+<!-- wp:group {"style":{"color":{"background":"#fff5ef"},"spacing":{"padding":{"top":"18px","right":"20px","bottom":"18px","left":"20px"},"margin":{"bottom":"28px"}},"border":{"radius":"3px","left":{"color":"#f3a77f","width":"4px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#f3a77f;border-left-width:4px;background-color:#fff5ef;margin-bottom:28px;padding:18px 20px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as an action, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;credential&gt; from &lt;where it is created&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 ```
 
 Rules:
@@ -272,8 +291,20 @@ Rules:
 ```text
 <Paragraph 1: what the platform manages or does, then one line: with Bit Integrations you can automatically send data from your WordPress website to <Platform>.>
 
-For example, when someone submits a form, places an order, registers for an event, or completes another action on your site, Bit Integrations can <do the platform's main operation, using a real event label from staticData.js> without any manual data entry.
+For example, when <one concrete actor does one concrete thing>, Bit Integrations can <real event label from staticData.js> in <Platform> <with the static config that event needs>. When <a second, different concrete scenario>, it can <a second real event label>. <One line on what nobody has to do by hand any more.>
 ```
+
+The example paragraph is subject to **Use-case realism** below — the same rules
+that govern the ideas section. In particular:
+
+- **Never write "when someone submits a form, places an order, or registers as a
+  user".** That sentence fits every platform, which is exactly why it is worthless
+  — it describes no real workflow and pairs generic triggers with whatever events
+  happen to exist.
+- Pick the two scenarios by reading the required fields of the events you name.
+  An event taking `user_id` and `course_id` gets an LMS scenario, not a contact
+  form one.
+- Name a role, not "someone": a contributor, an editor, a student, a customer.
 
 Human-written, simple, customer-friendly. No stiff marketing copy, no developer
 jargon.
@@ -285,11 +316,16 @@ One paragraph, a two-item list, then one closing paragraph:
 ```text
 Every integration in Bit Integrations has two halves. The trigger is what starts the workflow. The action is what happens as a result. When <Platform> is the action, <plain-language statement of where the platform sits — e.g. "your CRM sits at the receiving end">.
 
-- Trigger: an event in another app, such as a Contact Form 7 submission, a WooCommerce order, or a new user registration.
+- Trigger: an event in another app, such as <3 trigger events that genuinely suit this platform, each naming its plugin>.
 - Action: a <Platform> operation, such as <3-4 real event labels from staticData.js>.
 
 Bit Integrations catches the incoming data; you decide which incoming field belongs in which <Platform> field, and from that point on, the record is created for you every single time. <For same-site WordPress plugins, add: Everything runs on your own WordPress install.>
 ```
+
+The three trigger examples in that list must suit **this** platform — a video
+plugin gets a video submission, an LMS lesson completion and an opt-in; a CRM
+gets a checkout, a signup and a support request. Do not reuse one generic trio
+across docs.
 
 ### Before You Start
 
@@ -298,7 +334,7 @@ A short bullet list of real prerequisites only:
 ```text
 - Bit Integrations is installed and activated on your WordPress site.
 - <Platform> is installed and activated on the same site.   <- only for AUTH_TYPES.WP_PLUGIN_CHECK integrations; use the exact sentence from noteDetails.note when present
-- The trigger plugin you want to use, for example, Contact Form 7 or WooCommerce, is installed and has at least one form or product ready.
+- The trigger plugin you want to use, for example, <two plugins that genuinely suit this platform>, is installed and has at least one <form / course / product> ready.
 - A <Platform> account with <the credential the connection needs, named with the UI label>.   <- for API/OAuth integrations
 - Bit Integrations Pro is active.   <- only when any staticData.js event is is_pro: true
 ```
@@ -335,13 +371,38 @@ sub-steps.
 
 ### Step 1: Create the Integration and Set Up Your Trigger
 
+This step uses **two fixed screenshots**, not placeholders. Both are the same on
+every action doc, so they come from `.env` and are embedded as real images:
+
+| Position | `.env` key | What it shows |
+|---|---|---|
+| after paragraph 1 | `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID` | the welcome screen with the **Create Integration** button highlighted |
+| after paragraph 2 | `DOC_TRIGGER_LIST_ATTACHMENT_POST_ID` | the **Please select a Trigger** screen with the trigger plugin grid |
+
+Split the prose so each image sits under the sentence it illustrates. Do not
+put both images at the end of the step, and do not use
+`{{PLACEHOLDER:select-trigger}}` here — that slot no longer exists.
+
 ```text
-From your WordPress dashboard, open Bit Integrations and click Create Integration. On the trigger selection screen, search for the plugin you want to pull data from and select it. Contact Form 7 is a good first choice for a test run.
+From your WordPress dashboard, open Bit Integrations and click Create Integration.
+
+<DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID image>
+
+On the Please select a Trigger screen, type the plugin you want to pull data from into the Search Trigger... box and click its card. Contact Form 7 is a good first choice for a test run.
+
+<DOC_TRIGGER_LIST_ATTACHMENT_POST_ID image>
 
 Complete the trigger setup for that plugin, which usually means picking the specific form and running a test submission so Bit Integrations can read the field structure. Once that is done, you land on the action selection screen.
 ```
 
-Then `{{PLACEHOLDER:select-trigger}}`.
+`Please select a Trigger` and `Search Trigger...` are the real strings
+(`frontend/src/components/Flow/New/SelectTrigger.jsx`), matching the
+`Please select an Action` label used in Step 2.
+
+Resolve both IDs through `GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>` and embed
+`source_url` with the real-image block. Alt text must describe what is actually
+in the frame — neither screenshot contains the platform, so do not write an alt
+claiming it does.
 
 ### Step 2: Search and Select `<Platform>` as the Action
 
@@ -453,7 +514,7 @@ two-column table:
 
 | Column | Content |
 |---|---|
-| `Action Event` | The exact `label` string from `staticData.js`, bolded. Append ` (PRO)` when `is_pro: true` |
+| `Action Event` | The exact `label` string from `staticData.js`, bolded. Nothing appended |
 | `What It Does` | One or two sentences, grounded in `RecordApiHelper.php` — which endpoint it hits and what it needs mapped |
 
 Example row from the canonical doc:
@@ -464,6 +525,13 @@ Example row from the canonical doc:
 Never reword an event label. When the integration has fewer than about eight
 events, one ungrouped table without H4s is fine — the published Sender doc does
 that.
+
+**Never append a `(PRO)` marker to an event label**, in this table or anywhere
+else in the doc. A marker repeated on every row carries no information, and a
+marker on some rows reads as an upsell in the middle of a reference table.
+State plan gating once, in prose, where it changes what the reader does:
+`Bit Integrations Pro` in `Before You Start`, and a third-party plan
+requirement as its own sentence at the step where the reader picks the event.
 
 ### Step 5: Configure the Action Fields
 
@@ -530,8 +598,64 @@ Then the body of the block:
 ```
 
 Use four or five ideas. Trigger plugin names must come from
-`backend/Core/Util/AllTriggersName.php`; the operations named must come from
-`staticData.js`.
+`backend/Core/Util/AllTriggersName.php` or a free trigger's
+`{Name}Controller::info()`; the operations named must come from `staticData.js`.
+
+### Use-case realism — hard rules
+
+Every idea must be an automation a real site owner would actually build. This is
+the section most likely to go wrong, because generic pairings read fine and are
+completely wrong.
+
+**Derive the pairing from the action's field signature, not from a generic
+trigger list.** Read the required fields in `staticData.js` and the guard clauses
+in the Pro helper *before* choosing a trigger. The fields name the caller:
+
+| Required fields on the event | What that implies |
+|---|---|
+| `user_id`, `course_id`, `step_id` | an LMS trigger — a lesson or course event |
+| an email plus a record identifier | an opt-in or registration form |
+| a record ID the reader must already know | a form where a human types that ID, or an edit/admin flow |
+| only free text | an intake form, submitted by a person |
+
+**Never claim an outcome the code cannot produce.** Check what the helper writes,
+then describe exactly that and nothing more. Recurring traps:
+
+- Adding a record to a container is **not** granting a person access to it.
+  A playlist, list, group or category is content grouping. Unless the helper
+  writes an entitlement, permission or membership row, never write a use case
+  about a buyer "getting", "receiving" or "unlocking" anything.
+- Writing a row to an email table is **not** sending an email.
+- Recording analytics is **not** changing what a visitor sees.
+- Creating a draft is **not** publishing.
+
+**Every field the action needs must be obtainable from that trigger.** If the
+event requires a record ID and the trigger is a public form, the use case has to
+say the submitter supplies that ID — or pick a different trigger. Never leave a
+required field unaccounted for.
+
+**Banned opener.** Do not write "when someone submits a form, places an order, or
+registers as a user" — or any variant that lists generic triggers and staples
+them to whatever events exist. Name one concrete actor doing one concrete thing:
+a contributor, an editor, a student, a customer.
+
+**State the manual work removed.** One clause naming what the reader stops doing
+by hand is what makes a use case useful rather than decorative.
+
+**Name the real gotcha** when the event has one — a plan requirement, a field
+that must already exist, an irreversible write. A use case that hides the
+condition sends the reader into a failed run.
+
+Worked example of the failure this rule exists to prevent:
+
+> ✗ "A customer completes an order in WooCommerce → **Add Media to Playlist** →
+> the buyer gets the content the moment the order completes."
+> The helper appends media IDs to a playlist's settings array. There is no
+> per-user playlist and no entitlement. The automation described does not exist.
+>
+> ✓ "A student completes a lesson in LearnDash LMS → **Record Watch
+> Progression**." The event takes `user_id`, `watched_duration`, `course_id` and
+> `step_id`, so an LMS is what it was shaped for.
 
 ### Use-case title link
 
@@ -589,6 +713,107 @@ Close with one wrap-up paragraph:
 ```text
 These <N> barely scratch the surface. Bit Integrations connects 378+ apps to <Platform>, including <6-8 real trigger plugin names>. The setup process is the same every time.
 ```
+
+## Block vocabulary — visual hierarchy
+
+Three styled block types, and no others. Every doc uses the same three so the
+Users Guide reads as one system. All colours are **inline**, because EazyDocs has
+no theme CSS behind custom classes; inline styles on `wp:group` survive the REST
+sanitiser, custom class names do not.
+
+The rule that governs all three: **how loud a block may be depends on how many
+times the reader meets it.** A block seen once can shout. A block that repeats
+five times must whisper, or it becomes noise and drowns the one that matters.
+
+| Tier | Block | Times per doc | Left bar | Fill | Border |
+|---|---|---|---|---|---|
+| 1 | TL;DR | exactly 1 | `#f3a77f` 4px | `#fff5ef` | — |
+| 2 | Warning | 2-4 | `#d97757` 4px | `#fdf3f0` | — |
+| 3 | Use-case card | 4-5 | — | `#fdfcfb` | 1px `#e8e2dd` |
+
+Same shape, different colour, is what makes the vocabulary learnable. Do not
+invent a fourth style, and do not box anything outside these three.
+
+**Leave plain:** overview paragraphs, step bodies, tables and the event
+accordion. Tables already carry their own structure and steps are already
+delimited by their H3s, so boxing them tips the page into a wall of panels.
+
+### Inner margins — required on every styled block
+
+A styled group sets its own padding, and the theme also puts a bottom margin on
+the last `<p>` or `<ul>` inside it. The two stack, so the block renders with a
+visibly larger gap at the bottom than the top. Most themes use
+`margin: 0 0 1em`, which is why the defect shows up only at the bottom.
+
+Zero the inner margins explicitly — the group's padding is then the only
+spacing, and the box is symmetric:
+
+| Group contains | Fix |
+|---|---|
+| one paragraph (TL;DR, warning) | `margin-top:0;margin-bottom:0` on that paragraph |
+| several blocks (use-case card) | `margin-top:0` on the first block, `margin-bottom:0` on the last |
+
+Set it in **both** places, the block comment attribute and the inline `style`,
+or the editor and the front end disagree:
+
+```html
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0">TEXT</p><!-- /wp:paragraph -->
+
+<!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li>ITEM</li></ul><!-- /wp:list -->
+```
+
+Never fix this by shrinking the group's bottom padding — that depends on the
+theme's font size and breaks the moment the theme changes.
+
+### Tier 2 — warning callout
+
+For the conditions that cost the reader a failed run. Place each one **before**
+the action it protects. Quote the exact error string from the helper when there
+is one — a reader who has already hit it will search for that text.
+
+Earns a warning:
+
+- a plan gate, on either side (`Bit Integrations Pro`, the platform's own Pro
+  tier, a third-party API tier)
+- an irreversible write — permanent delete, overwrite, "cannot be undone"
+- a precondition that makes the action fail — a record that must already exist,
+  a field that must already be populated
+
+Does not earn one: anything already obvious from the field table, or a mere
+preference.
+
+```html
+<!-- wp:group {"style":{"color":{"background":"#fdf3f0"},"spacing":{"padding":{"top":"14px","right":"18px","bottom":"14px","left":"18px"},"margin":{"top":"18px","bottom":"18px"}},"border":{"radius":"3px","left":{"color":"#d97757","width":"4px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#d97757;border-left-width:4px;background-color:#fdf3f0;margin-top:18px;margin-bottom:18px;padding:14px 18px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>LEAD CONDITION.</strong> WHAT HAPPENS AND WHAT TO DO INSTEAD.</p><!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+```
+
+State a gate **once**. If a warning callout covers a requirement, delete the
+duplicate sentences elsewhere — repeating the same fact three times reads as
+padding and pushes the real content down.
+
+### Tier 3 — use-case card
+
+Wraps each block in the use-case section: the linked bold title, the rationale
+paragraph, and the Trigger/Action list. Quietest treatment of the three, because
+it repeats.
+
+```html
+<!-- wp:group {"style":{"color":{"background":"#fdfcfb"},"spacing":{"padding":{"top":"20px","right":"22px","bottom":"20px","left":"22px"},"margin":{"top":"16px","bottom":"16px"}},"border":{"radius":"4px","color":"#e8e2dd","width":"1px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-color:#e8e2dd;border-width:1px;border-radius:4px;background-color:#fdfcfb;margin-top:16px;margin-bottom:16px;padding:20px 22px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0">LINKED BOLD TITLE</p><!-- /wp:paragraph --><!-- wp:paragraph --><p class="wp-block-paragraph">RATIONALE</p><!-- /wp:paragraph --><!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li><strong>Trigger:</strong> …</li><li><strong>Action:</strong> …</li></ul><!-- /wp:list --></div>
+<!-- /wp:group -->
+```
+
+### The existing note callout
+
+The site's `note_col` block still exists and renders an info icon above the
+literal word **Note**. Use it only for genuine asides. Never use it for the
+TL;DR — it would label the primary path as an aside — and never for a warning,
+which needs its own colour.
+
+After setting content, verify the blocks survived by refetching with
+`context=edit` and confirming each fill and bar colour is still present in
+`content.raw`.
 
 ## Gutenberg snippets
 
@@ -660,9 +885,11 @@ must follow the site's style — a plain sentence describing the shot. The alts
 below are the ones used in the canonical Bit CRM doc, with the platform
 substituted.
 
+Step 1 has no placeholder slot — it uses the two fixed screenshots from `.env`
+described in the Step 1 section above.
+
 | Slot | Alt text |
 |---|---|
-| `select-trigger` | `Choose a trigger plugin` |
 | `select-action-app` | `Search and select <Platform> as an action` |
 | `add-connection-form` | `Add a <Platform> connection in Bit Integrations` |
 | `credential-source` | `<Platform> settings page where the credential is copied from` |
@@ -681,7 +908,9 @@ upload or cache these images.
 
 Read credentials, the parent section post ID, and media IDs from `.env`:
 `DOC_SITE_URL`, `DOC_SITE_USERNAME`, `DOC_SITE_PASSWORD`,
-`DOC_ACTION_PARENT_POST_ID`, `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`.
+`DOC_ACTION_PARENT_POST_ID`, `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`,
+`DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`,
+`DOC_TRIGGER_LIST_ATTACHMENT_POST_ID`.
 `DOC_SITE_PASSWORD` must be a WordPress Application Password. Never print it.
 
 Resolve an attachment:

--- a/.claude/skills/create-trigger-doc/SKILL.md
+++ b/.claude/skills/create-trigger-doc/SKILL.md
@@ -94,6 +94,10 @@ Verify first. Abort with the exact fix if missing.
    `frontend/src/components/Flow/New/SelectAction.jsx`. Use six recognizable
    `type` values verbatim. Never name an action integration that is not in that
    array.
+   Choose each destination by what the trigger event's payload actually
+   carries — an event with no email address cannot feed an email marketing app.
+   See "Use-case realism" in [reference.md](reference.md) before writing the
+   overview or any use case.
 6. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
    secondary/sidebar title, in-content H1, the mandatory TL;DR paragraph,
    three overview paragraphs, the
@@ -120,10 +124,16 @@ Verify first. Abort with the exact fix if missing.
    soft-404s and a `200` alone does not prove a page exists. See the
    "Use-case title link" section of `reference.md`.
    Include an **SEO/readability self-check** in the preview, confirming against
-   the standards in `reference.md`. Report it in four groups:
+   the standards in `reference.md`. Report it in six groups:
    - *Accuracy* — every event label, field label and button text traced to a
      source file; no behavior borrowed from another platform; every
-     `[VERIFY: …]` flag listed; Pro/version gating stated where it matters.
+     `[VERIFY: …]` flag listed; Pro/version gating stated where it matters; no
+     `(PRO)` marker anywhere.
+   - *Use-case realism* — for **each** use case and each overview example,
+     one line naming the trigger event's payload and confirming the destination
+     app can actually consume it; no generic "submits a form, places an order,
+     or registers" opener; no claimed outcome neither side produces. See
+     "Use-case realism" in `reference.md`.
    - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
      the meta description and exactly one image alt; one H1, no skipped heading
      levels; link count; no duplicated content with the platform's action doc.
@@ -131,8 +141,12 @@ Verify first. Abort with the exact fix if missing.
      sentences; no orphan pronouns; platform name repeated in each major
      section; specifics in tables not prose; no hedging words.
    - *Readability* — paragraph and sentence length, active voice, second person,
-     every image alt filled, no banned words (`simply`, `just`, `easy`,
-     `seamlessly`, …), every step imperative with an observable result.
+     every image alt filled and honest about what the shot contains, no banned
+     words (`simply`, `just`, `easy`, `seamlessly`, …), every step imperative
+     with an observable result.
+   - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
+     each one warns about) and the use-case cards, with counts. No fourth block
+     style, nothing boxed outside those three.
    The whole doc is public-facing; get explicit approval on the title and the
    self-check before creating anything.
 10. **Create a draft child doc** through EazyDocs using the full public title and

--- a/.claude/skills/create-trigger-doc/SKILL.md
+++ b/.claude/skills/create-trigger-doc/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: create-trigger-doc
+description: Generate one Bit Integrations Users Guide draft doc for a trigger integration, mined from the free/pro PHP trigger code and the React trigger UI. Use when the user invokes /create-trigger-doc with a platform name only or asks to document/generate docs for a trigger integration only.
+---
+
+# Create Trigger Doc
+
+Generates **one** Users Guide doc for a platform's triggers: the full setup flow
+is walked through step by step, every trigger event is listed in a collapsible
+"See all available `<Platform>` trigger events in Bit Integrations" accordion,
+and the result is created as a draft EazyDocs child post under the
+**Trigger** section on `bit-integrations.com`.
+
+Output must match the shape of the already-published trigger docs at
+`https://bit-integrations.com/wp-docs/trigger/`. The canonical example to follow
+is
+`https://bit-integrations.com/wp-docs/trigger/bit-crm-integration-as-a-trigger/`
+(post ID `124651`).
+
+The **entire document** must be SEO-friendly and user-friendly — not just the
+title. See the writing standards at the top of [reference.md](reference.md).
+
+## Invocation
+
+```text
+/create-trigger-doc <platform-name>
+```
+
+- `platform-name` is either the **registry key** (the directory name under
+  `backend/Triggers/` or `../bit-integrations-pro/backend/Triggers/`, e.g.
+  `WC`, `EDD`, `FluentCrm`) or the **display name** from
+  `backend/Core/Util/AllTriggersName.php` (e.g. `WooCommerce`,
+  `Easy Digital Downloads`, `Fluent CRM`).
+
+If `platform-name` is missing, ask before doing anything. Do not ask for the
+parent section post ID; read it from `DOC_TRIGGER_PARENT_POST_ID` in `.env`.
+
+## Prerequisites
+
+Verify first. Abort with the exact fix if missing.
+
+1. `.env` at the plugin root contains `DOC_SITE_URL`, `DOC_SITE_USERNAME`,
+   `DOC_SITE_PASSWORD`, `DOC_TRIGGER_PARENT_POST_ID`,
+   `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`, and
+   `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`. Copy `.env.example` to `.env`
+   and fill it if absent. Never print `DOC_SITE_PASSWORD`; HTTPS only.
+2. `DOC_SITE_PASSWORD` must be a WordPress **Application Password**, not the
+   wp-admin login password.
+3. `DOC_SITE_USERNAME` must be an Administrator or otherwise hold the EazyDocs
+   `edit_docs`/`publish_docs` capabilities. The `create-child` endpoint uses a
+   publish-permission check and returns 403 without them.
+
+## Workflow
+
+1. **Resolve the platform.** Look the argument up in
+   `backend/Core/Util/AllTriggersName.php` — the map is
+   `'<Key>' => ['name' => '<Display Name>', 'isPro' => bool]`. The `name` value
+   is the authoritative public platform name used in the title, slug, and body.
+   Locate the trigger directory: `backend/Triggers/<Key>/` (free) or
+   `../bit-integrations-pro/backend/Triggers/<Key>/` (pro). If the key is
+   present in `AllTriggersName.php` but no directory exists, stop and say so —
+   the trigger is listed for upsell only.
+2. **Read `<Key>Controller.php::info()`** and collect `name`, `type`,
+   `documentation_url`, `tutorial_url`, `is_active`, and the endpoint
+   descriptors (`list` / `tasks` / `fields` / `fetch`). `type` decides the
+   whole walkthrough — see the branch table in
+   [reference.md](reference.md).
+   - If `documentation_url` already points at a live doc, say so and confirm
+     with the user before creating a second one.
+3. **Collect the trigger event list.** Source depends on `type`:
+   - `form` / `custom_form_submission` with a fixed event set — the `list` or
+     `tasks` endpoint handler in the controller (usually `getAll()`, sometimes
+     `getAllTask()` / `tasks()`), which returns
+     `['id' => static::SOME_CONST, 'title' => __('Label')]` entries. Those
+     `title` values are the exact event labels; never invent or reword them.
+   - `form` where the list is the site's own forms/posts (e.g. Gravity Forms,
+     Contact Form 7) — there is no fixed event table. Skip the event accordion
+     and document form selection instead.
+   - `webhook` / `action_hook` / `custom_trigger` — no event list. Document the
+     webhook URL / hook name flow instead.
+   Cross-check every event against `<Key>/Hooks.php`: the `add_action` bindings
+   there are ground truth for the "When It Fires" column. Also read
+   `<Key>Helper.php` / `<Key>StaticFields.php` when present.
+4. **Read the trigger UI wording** from the React component that matches
+   `type`, so the doc quotes real button and heading labels:
+   - `form` → `frontend/src/components/Triggers/FormPlugin.jsx`
+   - `custom_form_submission` → `frontend/src/components/Triggers/CustomFormSubmission.jsx`
+   - `webhook` → `frontend/src/components/Triggers/Webhook.jsx`
+   - `action_hook` → `frontend/src/components/Triggers/ActionHook.jsx`
+   - `custom_trigger` → `frontend/src/components/Triggers/CustomTrigger.jsx`
+   The app-selection screen wording lives in
+   `frontend/src/components/Flow/New/SelectTrigger.jsx`.
+5. **Collect destination platforms for the overview** from the `integs` array in
+   `frontend/src/components/Flow/New/SelectAction.jsx`. Use six recognizable
+   `type` values verbatim. Never name an action integration that is not in that
+   array.
+6. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
+   secondary/sidebar title, in-content H1, the mandatory TL;DR paragraph,
+   three overview paragraphs, the
+   `How the <Platform> Trigger Works` and `Before You Start` H2 sections, the
+   `How to Set Up ... in Bit Integrations` H2, sequential Title Case
+   `Step N: ...` H3 headings, the event accordion, the closing paragraph, and
+   the `Explore <N> Useful ... Use Cases` H2 section.
+   Apply the SEO and readability standards at the top of `reference.md` as you
+   write, not as a pass afterwards.
+7. **Resolve media.** Read attachment post IDs from `.env` and resolve each
+   through `GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>`. Every
+   `{{PLACEHOLDER:<slot>}}` uses `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`. Do not
+   upload or cache images.
+8. **Read the parent section post ID** from `DOC_TRIGGER_PARENT_POST_ID` in
+   `.env` (the `Trigger` section, currently `2652`).
+9. **Preview for approval before creating the doc:** WordPress/public post
+   title, EazyDocs secondary/sidebar title, slug, trigger `type` branch used,
+   event count, event labels, the action platforms named in the overview and use
+   cases, the numbered H3 step titles, internal/external links added, media IDs
+   used, and the parent section id.
+   Each use-case title is a link to its
+   `bit-integrations.com/triggers/<platform>/connect/<app>/` page — list those
+   URLs in the preview with the `<title>` each one returned, because that site
+   soft-404s and a `200` alone does not prove a page exists. See the
+   "Use-case title link" section of `reference.md`.
+   Include an **SEO/readability self-check** in the preview, confirming against
+   the standards in `reference.md`. Report it in four groups:
+   - *Accuracy* — every event label, field label and button text traced to a
+     source file; no behavior borrowed from another platform; every
+     `[VERIFY: …]` flag listed; Pro/version gating stated where it matters.
+   - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
+     the meta description and exactly one image alt; one H1, no skipped heading
+     levels; link count; no duplicated content with the platform's action doc.
+   - *Extractability* — every heading answered in its first one or two
+     sentences; no orphan pronouns; platform name repeated in each major
+     section; specifics in tables not prose; no hedging words.
+   - *Readability* — paragraph and sentence length, active voice, second person,
+     every image alt filled, no banned words (`simply`, `just`, `easy`,
+     `seamlessly`, …), every step imperative with an observable result.
+   The whole doc is public-facing; get explicit approval on the title and the
+   self-check before creating anything.
+10. **Create a draft child doc** through EazyDocs using the full public title and
+    set its Gutenberg content. Set `ezd_doc_secondary_title` to the platform
+    name as a **top-level** REST field through `wp/v2/docs/<id>` (a `meta.*`
+    payload is ignored). Confirm the field exists in the authenticated `OPTIONS`
+    schema first — it is exposed by a site-specific snippet, not by EazyDocs Pro
+    itself. Only when the field is absent from the schema, report the edit link
+    and ask the user to set the EazyDocs Pro **Secondary Title** field manually,
+    and do not report the sidebar-title work complete until the user confirms it
+    was saved. Also report which placeholder screenshots need replacement, and
+    every `[VERIFY: …]` flag still in the body — the draft must not go public
+    until all of them are resolved and removed.
+11. **Set the Rank Math SEO fields** on the created doc automatically (no
+    approval), via one authenticated
+    `POST $DOC_SITE_URL/wp-json/rankmath/v1/updateMeta` call. Rank Math writes
+    generic post meta, so this works on the EazyDocs `docs` post. Send
+    `objectID` = the doc post ID, `objectType` = `post`, and a `meta` object
+    with:
+    - `rank_math_focus_keyword`: 3-4 comma-separated keyword phrases derived
+      from the doc (platform name + "integration"/"trigger" + the automation
+      value), **most important first** — the first phrase is the primary keyword
+      Rank Math scores on. Example for WooCommerce:
+      `woocommerce trigger, woocommerce bit integrations, woocommerce automation,
+      woocommerce order webhook`. (Multiple keywords need Rank Math Pro; on free
+      only the first is used, which is why the primary must be first.)
+    - `rank_math_description`: an AI-written meta description. **Do not open with
+      the post title or the phrase "<Platform> Integration as a Trigger"** —
+      start with the platform name early, then weave **semantic keywords** for
+      the use case (connect, sync, automate, workflow, trigger, plus domain terms
+      like "order data", "form entries", "CRM contacts"). Mention Bit
+      Integrations **once, briefly**, and include the primary focus keyword
+      naturally so Rank Math scores it green.
+      **150-160 characters, hard ceiling 160 — never exceed it.** Count the
+      characters and trim to <=160 before sending.
+    Write the keywords first, then compose the description to contain the primary
+    keyword. If the `rankmath/v1/updateMeta` route returns 404, report it and
+    skip — do not fail the doc.
+12. **Offer the code follow-up.** After the draft is created, report the future
+    public URL and offer to update `documentation_url` in
+    `<Key>Controller.php::info()` to point at it. Only edit the PHP when the
+    user says yes.
+
+## Notes
+
+- Read [reference.md](reference.md) only after the platform and trigger `type`
+  are known.
+- Event labels, field labels, and button text must be copied from the code, not
+  paraphrased. Platform-side navigation steps (where to find an API key, etc.)
+  may use general knowledge but must be flagged for human verification in the
+  approval preview.
+- Do not touch existing/previously created docs unless explicitly asked.

--- a/.claude/skills/create-trigger-doc/SKILL.md
+++ b/.claude/skills/create-trigger-doc/SKILL.md
@@ -17,7 +17,7 @@ is
 `https://bit-integrations.com/wp-docs/trigger/bit-crm-integration-as-a-trigger/`
 (post ID `124651`).
 
-The **entire document** must be SEO-friendly and user-friendly — not just the
+The **entire document** must be SEO-friendly and user-friendly - not just the
 title. See the writing standards at the top of [reference.md](reference.md).
 
 ## Invocation
@@ -53,30 +53,30 @@ Verify first. Abort with the exact fix if missing.
 ## Workflow
 
 1. **Resolve the platform.** Look the argument up in
-   `backend/Core/Util/AllTriggersName.php` — the map is
+   `backend/Core/Util/AllTriggersName.php`: the map is
    `'<Key>' => ['name' => '<Display Name>', 'isPro' => bool]`. The `name` value
    is the authoritative public platform name used in the title, slug, and body.
    Locate the trigger directory: `backend/Triggers/<Key>/` (free) or
    `../bit-integrations-pro/backend/Triggers/<Key>/` (pro). If the key is
-   present in `AllTriggersName.php` but no directory exists, stop and say so —
+   present in `AllTriggersName.php` but no directory exists, stop and say so -
    the trigger is listed for upsell only.
 2. **Read `<Key>Controller.php::info()`** and collect `name`, `type`,
    `documentation_url`, `tutorial_url`, `is_active`, and the endpoint
    descriptors (`list` / `tasks` / `fields` / `fetch`). `type` decides the
-   whole walkthrough — see the branch table in
+   whole walkthrough - see the branch table in
    [reference.md](reference.md).
    - If `documentation_url` already points at a live doc, say so and confirm
      with the user before creating a second one.
 3. **Collect the trigger event list.** Source depends on `type`:
-   - `form` / `custom_form_submission` with a fixed event set — the `list` or
+   - `form` / `custom_form_submission` with a fixed event set - the `list` or
      `tasks` endpoint handler in the controller (usually `getAll()`, sometimes
      `getAllTask()` / `tasks()`), which returns
      `['id' => static::SOME_CONST, 'title' => __('Label')]` entries. Those
      `title` values are the exact event labels; never invent or reword them.
    - `form` where the list is the site's own forms/posts (e.g. Gravity Forms,
-     Contact Form 7) — there is no fixed event table. Skip the event accordion
+     Contact Form 7) - there is no fixed event table. Skip the event accordion
      and document form selection instead.
-   - `webhook` / `action_hook` / `custom_trigger` — no event list. Document the
+   - `webhook` / `action_hook` / `custom_trigger`: no event list. Document the
      webhook URL / hook name flow instead.
    Cross-check every event against `<Key>/Hooks.php`: the `add_action` bindings
    there are ground truth for the "When It Fires" column. Also read
@@ -95,7 +95,7 @@ Verify first. Abort with the exact fix if missing.
    `type` values verbatim. Never name an action integration that is not in that
    array.
    Choose each destination by what the trigger event's payload actually
-   carries — an event with no email address cannot feed an email marketing app.
+   carries - an event with no email address cannot feed an email marketing app.
    See "Use-case realism" in [reference.md](reference.md) before writing the
    overview or any use case.
 6. **Author the Gutenberg doc** from [reference.md](reference.md): post title,
@@ -103,7 +103,8 @@ Verify first. Abort with the exact fix if missing.
    three overview paragraphs, the
    `How the <Platform> Trigger Works` and `Before You Start` H2 sections, the
    `How to Set Up ... in Bit Integrations` H2, sequential Title Case
-   `Step N: ...` H3 headings, the event accordion, the closing paragraph, and
+   `Step 01: ...` H3 headings, zero-padded to two digits, the event accordion,
+   the closing paragraph, and
    the `Explore <N> Useful ... Use Cases` H2 section.
    Apply the SEO and readability standards at the top of `reference.md` as you
    write, not as a pass afterwards.
@@ -119,43 +120,47 @@ Verify first. Abort with the exact fix if missing.
    cases, the numbered H3 step titles, internal/external links added, media IDs
    used, and the parent section id.
    Each use-case title is a link to its
-   `bit-integrations.com/triggers/<platform>/connect/<app>/` page — list those
+   `bit-integrations.com/triggers/<platform>/connect/<app>/` page - list those
    URLs in the preview with the `<title>` each one returned, because that site
    soft-404s and a `200` alone does not prove a page exists. See the
    "Use-case title link" section of `reference.md`.
    Include an **SEO/readability self-check** in the preview, confirming against
    the standards in `reference.md`. Report it in six groups:
-   - *Accuracy* — every event label, field label and button text traced to a
+   - *Accuracy* - every event label, field label and button text traced to a
      source file; no behavior borrowed from another platform; every
      `[VERIFY: …]` flag listed; Pro/version gating stated where it matters; no
      `(PRO)` marker anywhere.
-   - *Use-case realism* — for **each** use case and each overview example,
+   - *Use-case realism* - for **each** use case and each overview example,
      one line naming the trigger event's payload and confirming the destination
      app can actually consume it; no generic "submits a form, places an order,
      or registers" opener; no claimed outcome neither side produces. See
      "Use-case realism" in `reference.md`.
-   - *SEO* — primary keyword in the H1, the first 100 words, an H2, the slug,
+   - *SEO* - primary keyword in the H1, the first 100 words, an H2, the slug,
      the meta description and exactly one image alt; one H1, no skipped heading
      levels; link count; no duplicated content with the platform's action doc.
-   - *Extractability* — every heading answered in its first one or two
+   - *Extractability* - every heading answered in its first one or two
      sentences; no orphan pronouns; platform name repeated in each major
      section; specifics in tables not prose; no hedging words.
-   - *Readability* — paragraph and sentence length, active voice, second person,
+   - *Punctuation and step numbers* - zero em dashes and zero en dashes in
+     the whole doc, `<style>` block included (report both counts as `0`), and
+     every step heading zero-padded to two digits (`Step 01:`, `Step 02:`),
+     including any numbered sub-steps and any range named in prose.
+   - *Readability* - paragraph and sentence length, active voice, second person,
      every image alt filled and honest about what the shot contains, no banned
      words (`simply`, `just`, `easy`, `seamlessly`, …), every step imperative
      with an observable result.
-   - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
+   - *Block vocabulary* - the TL;DR group box, the warning callouts (list what
      each one warns about) and the use-case cards, with counts. No fourth block
      style, nothing boxed outside those three. Confirm each one carries its
      `bi-tldr`/`bi-warn`/`bi-card` class and **no inline colour**, and that the
-     `<style>` block is present as the first block of the content — inline
+     `<style>` block is present as the first block of the content - inline
      colours cannot express the site's dark mode.
-   - *Dark mode* — confirm the title has no `as a Trigger` phrasing
+   - *Dark mode* - confirm the title has no `as a Trigger` phrasing
      (`grep -i 'as \(a\|the\|your\) trigger'` must return 0) and that the doc
      renders in **both** modes. After publishing, load the page, toggle
      `body_dark`, and check the computed contrast of every `td/th/p/li/a/h1-h4`
      against its composited background; report the count of pairs under 4.5:1 in
-     each mode. Markup alone does not prove this — a theme `!important` rule can
+     each mode. Markup alone does not prove this - a theme `!important` rule can
      beat a correct-looking declaration.
    The whole doc is public-facing; get explicit approval on the title and the
    self-check before creating anything.
@@ -163,12 +168,12 @@ Verify first. Abort with the exact fix if missing.
     set its Gutenberg content. Set `ezd_doc_secondary_title` to the platform
     name as a **top-level** REST field through `wp/v2/docs/<id>` (a `meta.*`
     payload is ignored). Confirm the field exists in the authenticated `OPTIONS`
-    schema first — it is exposed by a site-specific snippet, not by EazyDocs Pro
+    schema first - it is exposed by a site-specific snippet, not by EazyDocs Pro
     itself. Only when the field is absent from the schema, report the edit link
     and ask the user to set the EazyDocs Pro **Secondary Title** field manually,
     and do not report the sidebar-title work complete until the user confirms it
     was saved. Also report which placeholder screenshots need replacement, and
-    every `[VERIFY: …]` flag still in the body — the draft must not go public
+    every `[VERIFY: …]` flag still in the body - the draft must not go public
     until all of them are resolved and removed.
 11. **Set the Rank Math SEO fields** on the created doc automatically (no
     approval), via one authenticated
@@ -178,23 +183,23 @@ Verify first. Abort with the exact fix if missing.
     with:
     - `rank_math_focus_keyword`: 3-4 comma-separated keyword phrases derived
       from the doc (platform name + "integration"/"trigger" + the automation
-      value), **most important first** — the first phrase is the primary keyword
+      value), **most important first**: the first phrase is the primary keyword
       Rank Math scores on. Example for WooCommerce:
       `woocommerce trigger, woocommerce bit integrations, woocommerce automation,
       woocommerce order webhook`. (Multiple keywords need Rank Math Pro; on free
       only the first is used, which is why the primary must be first.)
     - `rank_math_description`: an AI-written meta description. **Do not open with
-      the post title or the phrase "<Platform> Integration"** —
+      the post title or the phrase "<Platform> Integration"** -
       start with the platform name early, then weave **semantic keywords** for
       the use case (connect, sync, automate, workflow, trigger, plus domain terms
       like "order data", "form entries", "CRM contacts"). Mention Bit
       Integrations **once, briefly**, and include the primary focus keyword
       naturally so Rank Math scores it green.
-      **150-160 characters, hard ceiling 160 — never exceed it.** Count the
+      **150-160 characters, hard ceiling 160 - never exceed it.** Count the
       characters and trim to <=160 before sending.
     Write the keywords first, then compose the description to contain the primary
     keyword. If the `rankmath/v1/updateMeta` route returns 404, report it and
-    skip — do not fail the doc.
+    skip - do not fail the doc.
 12. **Offer the code follow-up.** After the draft is created, report the future
     public URL and offer to update `documentation_url` in
     `<Key>Controller.php::info()` to point at it. Only edit the PHP when the

--- a/.claude/skills/create-trigger-doc/SKILL.md
+++ b/.claude/skills/create-trigger-doc/SKILL.md
@@ -146,7 +146,17 @@ Verify first. Abort with the exact fix if missing.
      with an observable result.
    - *Block vocabulary* — the TL;DR group box, the warning callouts (list what
      each one warns about) and the use-case cards, with counts. No fourth block
-     style, nothing boxed outside those three.
+     style, nothing boxed outside those three. Confirm each one carries its
+     `bi-tldr`/`bi-warn`/`bi-card` class and **no inline colour**, and that the
+     `<style>` block is present as the first block of the content — inline
+     colours cannot express the site's dark mode.
+   - *Dark mode* — confirm the title has no `as a Trigger` phrasing
+     (`grep -i 'as \(a\|the\|your\) trigger'` must return 0) and that the doc
+     renders in **both** modes. After publishing, load the page, toggle
+     `body_dark`, and check the computed contrast of every `td/th/p/li/a/h1-h4`
+     against its composited background; report the count of pairs under 4.5:1 in
+     each mode. Markup alone does not prove this — a theme `!important` rule can
+     beat a correct-looking declaration.
    The whole doc is public-facing; get explicit approval on the title and the
    self-check before creating anything.
 10. **Create a draft child doc** through EazyDocs using the full public title and
@@ -174,7 +184,7 @@ Verify first. Abort with the exact fix if missing.
       woocommerce order webhook`. (Multiple keywords need Rank Math Pro; on free
       only the first is used, which is why the primary must be first.)
     - `rank_math_description`: an AI-written meta description. **Do not open with
-      the post title or the phrase "<Platform> Integration as a Trigger"** —
+      the post title or the phrase "<Platform> Integration"** —
       start with the platform name early, then weave **semantic keywords** for
       the use case (connect, sync, automate, workflow, trigger, plus domain terms
       like "order data", "form entries", "CRM contacts"). Mention Bit

--- a/.claude/skills/create-trigger-doc/reference.md
+++ b/.claude/skills/create-trigger-doc/reference.md
@@ -55,6 +55,10 @@ Documentation errors cost more than SEO errors.
 - Never mix platforms. A FluentPlayer doc contains only FluentPlayer behavior.
 - State a Pro-only or version-gated requirement at the point where it matters,
   not only in Before You Start.
+- **Never append a `(PRO)` marker** to an event label, feature name or table row.
+  A marker on every row carries no information; a marker on some rows reads as an
+  upsell inside a reference table. State plan gating once, in prose, where it
+  changes what the reader does.
 - If the platform cannot do what the keyword implies, say so plainly and early,
   then document the supported path.
 - Anything you could not verify from source becomes an inline
@@ -116,8 +120,18 @@ Documentation errors cost more than SEO errors.
 - Name the hub or parent page that will link **in** to this doc in the approval
   preview. For trigger docs that is the `Trigger` section
   (`DOC_TRIGGER_PARENT_POST_ID`), so no doc ships orphaned.
-- Every image needs descriptive alt text containing the platform name, stating
-  what the shot shows and where it is. No empty alts, no filename alts.
+- Every image needs descriptive alt text stating what the shot shows and where
+  it is. No empty alts, no filename alts.
+- **The alt must describe what is actually in the frame.** Name the platform
+  when the platform is visible; when the screenshot is a generic Bit Integrations
+  screen that does not contain it, describe that screen honestly and add the
+  platform only as context ("…, the first step of the `<Platform>` trigger
+  setup"). Never write an alt claiming a screenshot shows something it does not —
+  including a state that is not captured, such as "with a plugin chosen" on a
+  shot where nothing is selected.
+- Open every screenshot before writing its alt or placing it. The file name and
+  the attachment title are not reliable descriptions, and an image placed under
+  the wrong sentence is worse than a placeholder.
 - Put the primary keyword in exactly one alt, and only where it reads
   accurately. Do not repeat it across every alt.
 - Never let a step exist only inside a screenshot. The instruction must be in
@@ -234,7 +248,9 @@ paragraphs. It is the block a reader in a hurry acts on, and the block answer
 engines quote, so it carries the whole procedure in compressed form.
 
 ```html
-<!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as a trigger, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;prerequisites&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph -->
+<!-- wp:group {"style":{"color":{"background":"#fff5ef"},"spacing":{"padding":{"top":"18px","right":"20px","bottom":"18px","left":"20px"},"margin":{"bottom":"28px"}},"border":{"radius":"3px","left":{"color":"#f3a77f","width":"4px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#f3a77f;border-left-width:4px;background-color:#fff5ef;margin-bottom:28px;padding:18px 20px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as a trigger, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;prerequisites&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 ```
 
 Rules:
@@ -261,7 +277,7 @@ Rules:
 ```text
 <Paragraph 1: what the platform stores or does, in plain language, and one line saying Bit Integrations is what makes that data travel.>
 
-<Paragraph 2: once the two are connected, anything that happens in <Platform> can automatically start an action somewhere else — then name 4-5 concrete destinations, e.g. a WhatsApp message, a new row in Google Sheets, a Slack alert, a subscriber added to your email list.>
+<Paragraph 2: once the two are connected, anything that happens in <Platform> can automatically start an action somewhere else — then name 4-5 concrete destinations the platform's own payload can actually feed, e.g. a WhatsApp message, a new row in Google Sheets, a Slack alert, a subscriber added to your email list.>
 
 This guide walks through the full <Platform> trigger setup in Bit Integrations, lists every supported trigger event, and shows <N> practical automations you can build in a few minutes.
 ```
@@ -270,6 +286,12 @@ Human-written, simple, customer-friendly. No stiff marketing copy, no developer
 jargon. Every destination named in paragraph 2 must exist in the `integs` array
 in `frontend/src/components/Flow/New/SelectAction.jsx` — never invent an action
 integration.
+
+Paragraph 2 is subject to **Use-case realism** below. Each destination must be
+one the trigger's payload can genuinely feed: do not promise "a subscriber added
+to your email list" for an event that carries no email address. Read the event
+payload before naming destinations, and never open with "when someone submits a
+form, places an order, or registers as a user".
 
 ### How the `<Platform>` Trigger Works
 
@@ -481,6 +503,53 @@ Use four or five use cases. Every destination app must exist in the `integs`
 array in `SelectAction.jsx`; every trigger event must exist in the controller's
 list endpoint.
 
+### Use-case realism — hard rules
+
+Every use case must be an automation a real site owner would actually build.
+This is the section most likely to go wrong, because a generic pairing reads
+fine and is completely wrong.
+
+**Derive the pairing from the data the trigger event actually carries.** Read
+the event's payload (`getTestData()` / the controller's field list) *before*
+choosing a destination app. The payload decides what is possible:
+
+| What the event carries | Sensible destination |
+|---|---|
+| an email address and a name | an email marketing or CRM app |
+| an order or payment record | a spreadsheet, accounting or CRM app |
+| a support or form message | a chat app, helpdesk or notification channel |
+| only an internal record ID | another app on the same site, or nothing — pick a different event |
+
+If the destination needs a field the trigger never sends, the use case is
+invalid. Never assume a payload contains an email, a phone number or a total.
+
+**Never claim an outcome neither side can produce.** Describe exactly what the
+action app does with the data and nothing more. Recurring traps:
+
+- Adding a contact to a list is **not** sending them a message.
+- Writing a spreadsheet row is **not** generating a report.
+- Creating a record is **not** notifying a human, unless the action is a
+  notification.
+
+**Banned opener.** Do not write "when someone submits a form, places an order, or
+registers as a user" — or any variant that lists generic events and staples them
+to whatever destinations exist. Name one concrete actor doing one concrete
+thing: a customer, a student, a subscriber, a team member.
+
+**State the manual work removed.** One clause naming what the reader stops doing
+by hand is what makes a use case useful rather than decorative.
+
+**Name the real gotcha** when the pairing has one — a Pro requirement, a field
+the reader must map manually, a plan tier on the destination app's side.
+
+Worked example of the failure this rule exists to prevent:
+
+> ✗ "When a visitor views a page, send them a welcome email through Mailchimp."
+> A page-view event carries no email address, so the automation cannot run.
+>
+> ✓ "When a customer completes checkout, add them to a Mailchimp audience."
+> The checkout payload carries the email and name the audience needs.
+
 ### Use-case title link
 
 Each title links to the marketing-site connect page for that exact pairing:
@@ -534,6 +603,107 @@ Close with one wrap-up paragraph:
 ```text
 These <N> are only the starting point. Bit Integrations connects <Platform> to 378+ apps, including <6-8 real platform names>. The setup process is the same every time.
 ```
+
+## Block vocabulary — visual hierarchy
+
+Three styled block types, and no others. Every doc uses the same three so the
+Users Guide reads as one system. All colours are **inline**, because EazyDocs has
+no theme CSS behind custom classes; inline styles on `wp:group` survive the REST
+sanitiser, custom class names do not.
+
+The rule that governs all three: **how loud a block may be depends on how many
+times the reader meets it.** A block seen once can shout. A block that repeats
+five times must whisper, or it becomes noise and drowns the one that matters.
+
+| Tier | Block | Times per doc | Left bar | Fill | Border |
+|---|---|---|---|---|---|
+| 1 | TL;DR | exactly 1 | `#f3a77f` 4px | `#fff5ef` | — |
+| 2 | Warning | 2-4 | `#d97757` 4px | `#fdf3f0` | — |
+| 3 | Use-case card | 4-5 | — | `#fdfcfb` | 1px `#e8e2dd` |
+
+Same shape, different colour, is what makes the vocabulary learnable. Do not
+invent a fourth style, and do not box anything outside these three.
+
+**Leave plain:** overview paragraphs, step bodies, tables and the event
+accordion. Tables already carry their own structure and steps are already
+delimited by their H3s, so boxing them tips the page into a wall of panels.
+
+### Inner margins — required on every styled block
+
+A styled group sets its own padding, and the theme also puts a bottom margin on
+the last `<p>` or `<ul>` inside it. The two stack, so the block renders with a
+visibly larger gap at the bottom than the top. Most themes use
+`margin: 0 0 1em`, which is why the defect shows up only at the bottom.
+
+Zero the inner margins explicitly — the group's padding is then the only
+spacing, and the box is symmetric:
+
+| Group contains | Fix |
+|---|---|
+| one paragraph (TL;DR, warning) | `margin-top:0;margin-bottom:0` on that paragraph |
+| several blocks (use-case card) | `margin-top:0` on the first block, `margin-bottom:0` on the last |
+
+Set it in **both** places, the block comment attribute and the inline `style`,
+or the editor and the front end disagree:
+
+```html
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0">TEXT</p><!-- /wp:paragraph -->
+
+<!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li>ITEM</li></ul><!-- /wp:list -->
+```
+
+Never fix this by shrinking the group's bottom padding — that depends on the
+theme's font size and breaks the moment the theme changes.
+
+### Tier 2 — warning callout
+
+For the conditions that cost the reader a failed run. Place each one **before**
+the action it protects. Quote the exact error string from the helper when there
+is one — a reader who has already hit it will search for that text.
+
+Earns a warning:
+
+- a plan gate, on either side (`Bit Integrations Pro`, the platform's own Pro
+  tier, a third-party API tier)
+- an irreversible write — permanent delete, overwrite, "cannot be undone"
+- a precondition that makes the action fail — a record that must already exist,
+  a field that must already be populated
+
+Does not earn one: anything already obvious from the field table, or a mere
+preference.
+
+```html
+<!-- wp:group {"style":{"color":{"background":"#fdf3f0"},"spacing":{"padding":{"top":"14px","right":"18px","bottom":"14px","left":"18px"},"margin":{"top":"18px","bottom":"18px"}},"border":{"radius":"3px","left":{"color":"#d97757","width":"4px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#d97757;border-left-width:4px;background-color:#fdf3f0;margin-top:18px;margin-bottom:18px;padding:14px 18px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>LEAD CONDITION.</strong> WHAT HAPPENS AND WHAT TO DO INSTEAD.</p><!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+```
+
+State a gate **once**. If a warning callout covers a requirement, delete the
+duplicate sentences elsewhere — repeating the same fact three times reads as
+padding and pushes the real content down.
+
+### Tier 3 — use-case card
+
+Wraps each block in the use-case section: the linked bold title, the rationale
+paragraph, and the Trigger/Action list. Quietest treatment of the three, because
+it repeats.
+
+```html
+<!-- wp:group {"style":{"color":{"background":"#fdfcfb"},"spacing":{"padding":{"top":"20px","right":"22px","bottom":"20px","left":"22px"},"margin":{"top":"16px","bottom":"16px"}},"border":{"radius":"4px","color":"#e8e2dd","width":"1px"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-background" style="border-color:#e8e2dd;border-width:1px;border-radius:4px;background-color:#fdfcfb;margin-top:16px;margin-bottom:16px;padding:20px 22px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0">LINKED BOLD TITLE</p><!-- /wp:paragraph --><!-- wp:paragraph --><p class="wp-block-paragraph">RATIONALE</p><!-- /wp:paragraph --><!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li><strong>Trigger:</strong> …</li><li><strong>Action:</strong> …</li></ul><!-- /wp:list --></div>
+<!-- /wp:group -->
+```
+
+### The existing note callout
+
+The site's `note_col` block still exists and renders an info icon above the
+literal word **Note**. Use it only for genuine asides. Never use it for the
+TL;DR — it would label the primary path as an aside — and never for a warning,
+which needs its own colour.
+
+After setting content, verify the blocks survived by refetching with
+`context=edit` and confirming each fill and bar colour is still present in
+`content.raw`.
 
 ## Gutenberg snippets
 

--- a/.claude/skills/create-trigger-doc/reference.md
+++ b/.claude/skills/create-trigger-doc/reference.md
@@ -1,0 +1,688 @@
+# create-trigger-doc reference
+
+Load only after the platform and its trigger `type` are known.
+
+**Canonical published example:**
+`https://bit-integrations.com/wp-docs/trigger/bit-crm-integration-as-a-trigger/`
+(post ID `124651`). When this reference and that doc disagree, the published doc
+wins — fetch it with
+`curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs/124651?_fields=content"` and match it.
+
+## Writing standards — SEO and readability
+
+These apply to the **entire document**, not just the title. Check them before
+sending the doc for approval.
+
+**Keywords**
+
+- Primary keyword: `<Platform> integration` (or `<Platform> trigger` where it
+  reads more naturally). It must appear in the H1, in the **first paragraph
+  within the first 100 words**, in at least one H2, in the slug, in the meta
+  description, and in at least one image alt.
+- Secondary keywords to weave in naturally across the body:
+  `<Platform> Bit Integrations`, `<Platform> automation`,
+  `WordPress <Platform> integration`, plus the domain terms the platform owns
+  (`CRM records`, `order data`, `form entries`, `subscribers`).
+- Natural density only. Never repeat the exact phrase in consecutive sentences,
+  never keyword-stuff a heading, never write a sentence whose only job is to
+  hold a keyword.
+- The trigger doc and the action doc for the same platform must not duplicate
+  each other. Different intros, different examples, different use cases.
+
+**Structure**
+
+- Exactly one H1. Never skip heading levels (H1 → H2 → H3 → H4).
+- Every heading is descriptive and front-loaded with the meaningful word — a
+  reader scanning only the headings must be able to follow the whole setup.
+- Answer-first: the first one or two sentences under **every** heading fully
+  answer that heading. No warm-up, no "in this section we will look at".
+- Use tables and bulleted lists instead of walls of text; the event accordion and
+  the use-case bullets exist for this reason.
+- This page is a **task doc**, not a tutorial or a concept page. It does not
+  teach what a webhook or a CRM is. Link out to the doc that does.
+
+**Accuracy — hard rules**
+
+Documentation errors cost more than SEO errors.
+
+- Never invent a feature, event, field, menu path, limit, plan tier or
+  destination app. If it is not in the source, it does not go in the doc.
+- Source-of-truth order: the trigger's `{Key}Controller.php` and `Hooks.php` →
+  `SelectAction.jsx` / the React trigger component → the platform's own official
+  docs. Nothing else. Not memory, not a similar integration, not a competitor.
+- Reproduce event labels, field labels and button text **character for
+  character** as the code emits them. Never reword, never fix their casing.
+- Never mix platforms. A FluentPlayer doc contains only FluentPlayer behavior.
+- State a Pro-only or version-gated requirement at the point where it matters,
+  not only in Before You Start.
+- If the platform cannot do what the keyword implies, say so plainly and early,
+  then document the supported path.
+- Anything you could not verify from source becomes an inline
+  `[VERIFY: exact wording of the API key screen in <Platform>]` flag in the
+  draft **and** a line in the approval preview. Never quietly guess.
+  Every `[VERIFY: …]` must be resolved and removed before the draft is
+  published — grep the content for `[VERIFY` as a release gate.
+
+**Extractability — how LLMs and answer engines read the page**
+
+- Every paragraph must survive being lifted out on its own. No orphan pronouns:
+  "This mapping lets you…", not "This lets you…".
+- Repeat the full platform name in each major section. Retrieval pulls
+  fragments, not whole pages, so a section that only says "the plugin" is
+  unattributable.
+- Give an extractable one-sentence definition where a term matters: "Field
+  mapping in Bit Integrations is the step where each trigger field is matched to
+  a destination field."
+- Numbers, limits, formats and prerequisites belong in a list or table, never
+  woven into prose.
+- No hedging. "May", "might", "possibly", "generally", "should normally" destroy
+  citation value. State the fact, or state its condition: "For logged-out
+  visitors, the flag lasts 24 hours."
+
+**Readability**
+
+- Second person, active voice, present tense. Short sentences — average under
+  20 words, split anything longer.
+- Paragraphs of three to four sentences at most.
+- Around a grade-8 reading level. Expand an acronym on first use.
+- No unexplained jargon, no internal code names, no class or method names in the
+  public body.
+- Bold the real UI labels the reader must find on screen (`Create Integration`,
+  `Select a Form/Task Name`, `Fetch`, `Set Action`). Bold is for UI labels and
+  warnings only, never for general emphasis.
+- Lead with the condition, not the consequence: "If your site is multisite, …".
+
+**Banned language**
+
+- Never `simply`, `just`, `easy`, `obviously`, `of course`. They shame a reader
+  who is already stuck.
+- Never `seamlessly`, `effortlessly`, `revolutionary`, `game-changing`,
+  `the possibilities are endless`, `let's dive in`, `in today's fast-paced
+  world`, `it's important to note that`.
+- Never promise a ranking, an AI citation or a rich snippet anywhere in the doc
+  or in the report about it.
+
+**Links and images**
+
+- Two to four internal links to related docs on `bit-integrations.com`: the
+  matching action doc for the same platform when it exists, the conditional
+  logic doc, and one or two related trigger docs. Anchor text must be
+  descriptive and carry the destination's own keyword — never `click here`,
+  never a bare URL.
+- Link once per destination per page. A second identical link adds nothing.
+- Link back to prerequisites and concepts, forward to the logical next task.
+- One external link to the platform's own site or API docs where credentials or
+  records are created, when relevant.
+- Name the hub or parent page that will link **in** to this doc in the approval
+  preview. For trigger docs that is the `Trigger` section
+  (`DOC_TRIGGER_PARENT_POST_ID`), so no doc ships orphaned.
+- Every image needs descriptive alt text containing the platform name, stating
+  what the shot shows and where it is. No empty alts, no filename alts.
+- Put the primary keyword in exactly one alt, and only where it reads
+  accurately. Do not repeat it across every alt.
+- Never let a step exist only inside a screenshot. The instruction must be in
+  the text; the image only confirms it.
+
+**Meta**
+
+- Meta description 150-160 characters, hard ceiling 160, containing the primary
+  keyword and not opening with the post title.
+
+## Post title, sidebar title, and slug
+
+EazyDocs Pro supports a separate sidebar label through the **Secondary Title**
+field (`ezd_doc_secondary_title`). The WordPress/EazyDocs post title must be the
+full public document title; never shorten `post_title` just to change the
+sidebar.
+
+**WordPress/EazyDocs post title:**
+
+```text
+<Platform> Integration as a Trigger
+```
+
+Examples: `Bit CRM Integration as a Trigger`,
+`NextCRM Integration as a Trigger`. Use the exact `name` value from
+`backend/Core/Util/AllTriggersName.php`. Use singular `Integration`, never
+`Integrations`.
+
+> **Note:** The post title must be SEO-friendly and user-friendly. Include the
+> exact platform name, use natural language, and avoid keyword stuffing, vague
+> claims, or awkward repetition.
+
+**EazyDocs Pro Secondary Title / sidebar label:**
+
+```text
+<Platform>
+```
+
+Examples: `Bit CRM`, `NextCRM`, `WooCommerce`. Save this value in
+`ezd_doc_secondary_title`. EazyDocs' left-sidebar walker reads it and falls back
+to `post_title` only when empty.
+
+**URL slug, fixed for trigger docs:**
+
+```text
+<platform-slug>-integration
+```
+
+Examples: `bit-crm-integration`, `nextcrm-integration`,
+`fluentplayer-integration`. Always singular `-integration`, and **no**
+`-as-a-trigger` suffix — the trigger doc owns the short, canonical slug.
+
+The post title still reads `<Platform> Integration as a Trigger`; only the slug
+drops the suffix. Action docs keep the full
+`<platform-slug>-integration-as-an-action`, so the two doc types never collide.
+
+| Doc type | Slug |
+|---|---|
+| Trigger | `<platform-slug>-integration` |
+| Action | `<platform-slug>-integration-as-an-action` |
+
+Older docs on the site use legacy slugs (`<platform>-integrations`,
+`<platform>-integrations-as-a-trigger`, `<platform>-integration-as-a-trigger`).
+Do not copy those for new docs, but do
+check whether a legacy doc for this platform already exists before creating a
+new one:
+
+```bash
+curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs?parent=$DOC_TRIGGER_PARENT_POST_ID&search=<Platform>&_fields=id,slug,title"
+```
+
+Also check the exact slug is free (`wp/v2/docs?slug=...`) — WordPress silently
+renames a duplicate to `...-2`. If it is taken, stop and confirm with the user.
+
+When posting the title to the EazyDocs `create-child` endpoint, replace `&` with
+`ezd_ampersand`, `#` with `ezd_hash`, and `+` with `ezd_plus`; that endpoint
+decodes them back via `decode_special_chars`. Send the title/slug **raw**
+(unencoded) to the core `wp/v2/docs/<id>` endpoint — it does not decode these
+tokens, so an encoded title would be stored literally.
+
+## Document structure
+
+The content opens with an H1 that repeats the post title — published trigger docs
+on this site keep the H1 inside the content, so match that. H2 for sections, H3
+for steps, H4 for event categories inside the accordion.
+
+Step headings use **Title Case** and no leading zero: `Step 1: Click the Fetch
+Button`, not `Step 01: click the fetch button`.
+
+```text
+<h1>  <Platform> Integration as a Trigger
+      <TL;DR paragraph>
+      <3 overview paragraphs>
+<h2>  How the <Platform> Trigger Works
+<h2>  Before You Start
+<h2>  How to Set Up <Platform> Integration as a Trigger in Bit Integrations
+      <one paragraph: how many steps and which one needs care>
+<h3>    Step 1: Open Bit Integrations and Click Create Integration
+<h3>    Step 2: Search and Select <Platform> as the Trigger
+<h3>    Step 3: Choose Your Trigger Event
+<h3>    Step 4: Click the Fetch Button
+<h3>    Step 5: Create a Test Record Within the 3 Minute Window
+<h3>    Step 6: Review the Fetched Data and Click Set Action
+      <closing paragraph>
+<h2>  Explore <N> Useful <Platform> Integration as a Trigger Use Cases
+```
+
+Do not add an Action walkthrough, a step summary, or a roadmap list.
+
+### TL;DR — mandatory, always first
+
+One paragraph, placed immediately after the H1 and before the overview
+paragraphs. It is the block a reader in a hurry acts on, and the block answer
+engines quote, so it carries the whole procedure in compressed form.
+
+```html
+<!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as a trigger, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;prerequisites&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph -->
+```
+
+Rules:
+
+- Two to four sentences. Never more.
+- It must work **alone**. An experienced reader acts on the TL;DR and never
+  scrolls further, so a path that only makes sense after reading Step 3 has
+  failed.
+- Name the real UI labels and a real event label, bolded, under the same
+  accuracy rules as the rest of the page — **Create Integration**, **Fetch**,
+  **Set Action**, and one event copied verbatim from the controller.
+- Contain the primary keyword naturally. This is inside the first 100 words, so
+  it satisfies that placement requirement.
+- State the prerequisites in the same breath, including
+  `Bit Integrations Pro` when `AllTriggersName.php` marks the trigger
+  `isPro: true`.
+- Give a time estimate only when the step count supports one. Do not invent a
+  number to fill the sentence.
+- Adjust the path per branch: a `webhook` trigger's TL;DR names copying the
+  webhook URL, not clicking Fetch.
+
+### Overview — 3 paragraphs
+
+```text
+<Paragraph 1: what the platform stores or does, in plain language, and one line saying Bit Integrations is what makes that data travel.>
+
+<Paragraph 2: once the two are connected, anything that happens in <Platform> can automatically start an action somewhere else — then name 4-5 concrete destinations, e.g. a WhatsApp message, a new row in Google Sheets, a Slack alert, a subscriber added to your email list.>
+
+This guide walks through the full <Platform> trigger setup in Bit Integrations, lists every supported trigger event, and shows <N> practical automations you can build in a few minutes.
+```
+
+Human-written, simple, customer-friendly. No stiff marketing copy, no developer
+jargon. Every destination named in paragraph 2 must exist in the `integs` array
+in `frontend/src/components/Flow/New/SelectAction.jsx` — never invent an action
+integration.
+
+### How the `<Platform>` Trigger Works
+
+One paragraph, a two-item list, then one closing paragraph:
+
+```text
+Bit Integrations follows a simple two-part model. The trigger is what happens. The action is what you want to happen next.
+
+- Trigger: an event inside <Platform>, such as <real event label A> or <real event label B>.
+- Action: one or more destination apps that receive the data, such as <6 real platform names from SelectAction.jsx>, or any of the other supported platforms.
+
+When a trigger event happens in <Platform>, Bit Integrations collects the record and its field data, then sends each value to the matching field in the connected app. The process runs on your WordPress site, so your customer data does not pass through a third-party automation service.
+```
+
+Keep the last sentence for triggers that run on-site. Drop or reword it for
+webhook triggers where the platform is external.
+
+### Before You Start
+
+A short bullet list of real prerequisites only:
+
+```text
+- Bit Integrations is installed and activated on your WordPress site.
+- <Platform> is installed and activated on the same site.   <- only for WordPress-plugin triggers
+- You know which destination app you want to send data to, and you have its necessary credentials or API key ready.
+- Bit Integrations Pro is active.   <- only when AllTriggersName.php marks this trigger isPro: true
+```
+
+For SaaS/webhook triggers, replace the second bullet with the account or plan the
+platform requires.
+
+### Setup section lead-in
+
+```text
+The whole setup takes <N> steps. Follow them in order, because the fetch step in the middle depends on a live test record.
+```
+
+Adjust for the branch — a `form`-listing trigger has no fetch step, so say what
+its fiddly step is instead.
+
+### Branch table
+
+The step sequence depends on `info()['type']`:
+
+| `type` | UI component | Step sequence |
+|---|---|---|
+| `custom_form_submission` | `CustomFormSubmission.jsx` | The 6-step Fetch flow below — this is the canonical shape |
+| `form` with a fixed event list (controller `getAll()` returns constant-backed titles) | `FormPlugin.jsx` | Steps 1-3 identical; there is no Fetch button, so Steps 4-6 collapse into `Step 4: Select Your Options and Click Next` |
+| `form` listing the site's own forms/posts | `FormPlugin.jsx` | Steps 1-2 identical; `Step 3: Choose Your Form` replaces the event step and there is no accordion; then `Step 4: Click Next` |
+| `webhook` | `Webhook.jsx` | Steps 1-2 identical; `Step 3: Copy the Webhook URL`, `Step 4: Paste the URL into <Platform>`, `Step 5: Send One Test Payload`, `Step 6: Review the Fetched Data and Click Set Action` |
+| `action_hook` / `custom_trigger` | `ActionHook.jsx` / `CustomTrigger.jsx` | Steps 1-2 identical; `Step 3: Register the Hook Name`, `Step 4: Fire the Hook Once`, `Step 5: Review the Fetched Data and Click Set Action` |
+
+### Step craft rules
+
+These apply to every `Step N:` heading, in every branch.
+
+- **One action per step.** If the body needs "and then", it is two steps.
+- Open each step with an imperative verb the reader can act on: Click, Open,
+  Select, Enter, Enable, Copy. Never "Configure as needed" — a step you cannot
+  describe concretely is not a step.
+- Name the exact UI element and its exact label, in the real path form:
+  **Bit Integrations → Create Integration**.
+- **State the observable result**, so the reader can confirm they are on track:
+  "The Fetch button changes to a spinning Waiting for form submission state."
+  Never end a step on a click.
+- Put a warning **before** the action it protects, never after.
+- When a step branches, give each branch its own labelled sentence or bullet
+  rather than nested "if … otherwise" prose.
+- The closing paragraph must contain a concrete success check the reader can
+  see — which screen to open and what should appear there — not just "you are
+  done".
+- Keep the count realistic. Past about ten steps, group them into phases.
+
+### Step 1: Open Bit Integrations and Click Create Integration
+
+```text
+From your WordPress dashboard, go to Bit Integrations. On the welcome screen or the integrations list, click the Create Integration button. This opens a trigger selection page.
+```
+
+Then the fixed screenshot `{{SHOT:create-integration}}` using
+`DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`.
+
+### Step 2: Search and Select `<Platform>` as the Trigger
+
+```text
+You will land on the trigger selection screen. Type <Platform> into the search box and click the <Platform> card when it appears.
+```
+
+The real screen heading is `Please select a Trigger`
+(`frontend/src/components/Flow/New/SelectTrigger.jsx`).
+
+Then `{{PLACEHOLDER:select-trigger-app}}`.
+
+### Step 3: Choose Your Trigger Event
+
+```text
+Open the Select a Form/Task Name dropdown and pick the trigger event you want to listen for. The dropdown holds every supported <Platform> event, so pick the one that matches the exact moment you want your automation to start.
+```
+
+`Select a Form/Task Name` is the real dropdown label — do not reword it.
+
+Then the **event accordion** (below), then:
+
+```text
+Popular starting points:
+
+- <Event Label> for <why someone would pick it>.
+- <Event Label> for <why>.
+- <Event Label> for <why>.
+```
+
+Use three to five events, labels copied verbatim from the controller.
+
+Then `{{PLACEHOLDER:select-trigger-event}}`.
+
+### Step 4: Click the Fetch Button
+
+```text
+After you select an event, a Fetch button appears. Click it. Bit Integrations now starts listening for a real record so it can learn the field structure of that event.
+```
+
+Then `{{PLACEHOLDER:fetch-button}}`.
+
+### Step 5: Create a Test Record Within the 3 Minute Window
+
+```text
+The Fetch button changes to a spinning "Waiting for form submission" state with a three-minute countdown. During that window, go and perform the exact action you selected in Step 3.
+
+The test record must match the trigger event you chose. If you selected <Event A>, <do X in the platform>. If you selected <Event B>, <do Y>. If you selected <Event C>, <do Z>.
+```
+
+`Waiting for form submission...` is the real button state
+(`CustomFormSubmission.jsx`). If the countdown ends before the test lands,
+nothing is broken — say so, and say to click Fetch again.
+
+Then `{{PLACEHOLDER:waiting-for-submission}}`.
+
+### Step 6: Review the Fetched Data and Click Set Action
+
+```text
+As soon as the test record is captured, the button turns into "Fetched" and a field table appears. Every field from that record is listed with its detected data type, and the sample values from your test record are shown alongside. Check that the fields you care about are there, for example <3-4 real field labels>, and adjust any data type from its dropdown if the detected type is not what you want.
+
+When the data looks right, click Set Action.
+```
+
+Then `{{PLACEHOLDER:fetched-fields}}`, then the closing paragraph:
+
+```text
+You are now on the action setup screen. Search for your destination app, connect it, map the <Platform> fields to the destination fields, and save the integration. From that point on, every matching <Platform> event runs the automation automatically.
+```
+
+## Event accordion
+
+Collapsed by default, headed
+`See all available <Platform> trigger events in Bit Integrations`.
+
+Inside it, group the events into categories derived from the constant names in
+the controller, each an `<h4>` named `<Module> Events` (`Lead Events`,
+`Contact Events`, `Deal Events`, `Invoice Events`, …), followed by one
+two-column table:
+
+| Column | Content |
+|---|---|
+| `Trigger Event` | The exact `title` string from the controller's list endpoint, bolded |
+| `When It Fires` | One or two sentences, grounded in the `add_action` binding in `Hooks.php` |
+
+Example row from the canonical doc:
+
+> **Lead Created** | Fires the moment a new lead is added to Bit CRM, whether it
+> was typed in manually, imported, or captured by a connected form.
+
+Never reword an event label. If a controller constant has no matching entry in
+the list endpoint, it is dead or deprecated — leave it out and mention it in the
+approval preview. When the trigger has fewer than about eight events, one
+ungrouped table without H4s is fine.
+
+Skip the accordion entirely when the trigger has no fixed event set.
+
+## Use-case section
+
+`<h2>` `Explore <N> Useful <Platform> Integration as a Trigger Use Cases`, then:
+
+```text
+Here are <N> automations that solve real problems for small teams. Each one uses the same <N>-step setup described above, with a different action app at the end.
+```
+
+Then one block per use case — the title is a **bold linked paragraph**, not a
+heading:
+
+```text
+**<Platform> <Destination App> Integration**   <- the whole title is a link
+```
+
+```html
+<!-- wp:paragraph --><p class="wp-block-paragraph"><a href="CONNECT_URL"><strong>&lt;Platform&gt; &lt;Destination App&gt; Integration</strong></a></p><!-- /wp:paragraph -->
+```
+
+Then the body of the block:
+
+```text
+<One short paragraph of rationale: why this automation matters, in human terms.>
+
+- Trigger: <real trigger event label>
+- Action: <what the destination app does>
+- What it does: <2-3 sentences describing the end result and one variation the reader could add>
+```
+
+Use four or five use cases. Every destination app must exist in the `integs`
+array in `SelectAction.jsx`; every trigger event must exist in the controller's
+list endpoint.
+
+### Use-case title link
+
+Each title links to the marketing-site connect page for that exact pairing:
+
+```text
+https://bit-integrations.com/triggers/<platform-connect-slug>/connect/<destination-connect-slug>/
+```
+
+Example: `https://bit-integrations.com/triggers/fluent-player/connect/google-sheets/`
+
+Both slugs belong to the marketing site and are **not derived** from anything in
+this repo — not the doc slug, not the `AllTriggersName.php` key, not the
+`integs` `type` value. Observed mismatches:
+
+| Source value | Connect slug |
+|---|---|
+| `FluentPlayer` (doc slug `fluentplayer-...`) | `fluent-player` |
+| `Google Sheet` | `google-sheets` |
+| `Fluent CRM` | `fluentcrm` |
+| `Mail Chimp` | `mailchimp` |
+
+**Verify every one of these links before the approval preview.**
+`bit-integrations.com` soft-404s: a missing connect page still answers HTTP
+`200` with a full-size body, so a status-code check proves nothing. The
+`<title>` is the only reliable signal.
+
+Verify **positively**. A live connect page's title matches
+`<Destination> Integration with <Platform> - Automate Your Tasks`. Do not test
+for a specific 404 string — the site serves at least two of them
+(`Page not found` and `Page Not Found - Bit Integrations`), so a match against
+one of those will pass a dead URL through.
+
+```bash
+curl -sL "https://bit-integrations.com/triggers/<platform>/connect/<app>/" \
+  | grep -o '<title>[^<]*</title>'
+# accept only if it reads "<App> Integration with <Platform> - Automate Your Tasks"
+```
+
+The pairing always lives under `/triggers/…/connect/…`, whichever side the doc
+is about. There is no `/actions/<app>/connect/<x>/` route — that path soft-404s.
+`/actions/<app>/` and `/integrations/<app>/` also resolve but serve an unrelated
+page, so never link to either.
+
+Start from the platform's own index, `https://bit-integrations.com/triggers/<platform-connect-slug>/`,
+to find which pairings exist. If a destination has no live connect page, choose a
+different destination app for that use case rather than shipping a dead link.
+Report the verified URLs in the approval preview.
+
+Close with one wrap-up paragraph:
+
+```text
+These <N> are only the starting point. Bit Integrations connects <Platform> to 378+ apps, including <6-8 real platform names>. The setup process is the same every time.
+```
+
+## Gutenberg snippets
+
+For the accordion, generate unique IDs per doc, such as `esab-abc1234` and
+`esab-child123`, then replace every `ACCORDION_ID` and `ACCORDION_CHILD_ID`
+placeholder consistently in the block comment, CSS selectors, and HTML class
+names.
+
+```html
+<!-- headings, paragraphs, lists -->
+<!-- wp:heading {"level":1} --><h1 class="wp-block-heading">TEXT</h1><!-- /wp:heading -->
+<!-- wp:heading --><h2 class="wp-block-heading">TEXT</h2><!-- /wp:heading -->
+<!-- wp:heading {"level":3} --><h3 class="wp-block-heading">TEXT</h3><!-- /wp:heading -->
+<!-- wp:heading {"level":4} --><h4 class="wp-block-heading">TEXT</h4><!-- /wp:heading -->
+<!-- wp:paragraph --><p class="wp-block-paragraph">TEXT</p><!-- /wp:paragraph -->
+<!-- wp:list --><ul class="wp-block-list"><li>ITEM</li></ul><!-- /wp:list -->
+
+<!-- two-column event table -->
+<!-- wp:table {"hasFixedLayout":true} -->
+<figure class="wp-block-table"><table class="has-fixed-layout"><thead><tr><th><strong>Trigger Event</strong></th><th><strong>When It Fires</strong></th></tr></thead><tbody><tr><td><strong>EVENT LABEL</strong></td><td>WHEN IT FIRES</td></tr></tbody></table></figure>
+<!-- /wp:table -->
+
+<!-- styled available-events accordion; use this instead of wp:details -->
+<!-- wp:esab/accordion {"uniqueId":"ACCORDION_ID","blockStyle":" .ACCORDION_ID.wp-block-esab-accordion, .ACCORDION_ID.wp-block-esab-accordion.nested-accordion{margin:0 0 30px 0;} .ACCORDION_ID.wp-block-esab-accordion > .esab__container{gap:10px;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child{border-style:solid;border-color:#f3a77f;border-width:1px;border-radius:3px;overflow:hidden;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child > .esab__head{background:#ffc0a6;padding:14px 10px;gap:8px;} .ACCORDION_ID.wp-block-esab-accordion .esab__heading_tag{color:#263a55;font-weight:700;margin:0;} .ACCORDION_ID.wp-block-esab-accordion .esab__icon svg{fill:#111111;width:20px;height:20px;} .ACCORDION_ID.wp-block-esab-accordion .esab__icon svg path{fill:#111111;} .ACCORDION_ID.wp-block-esab-accordion .wp-block-esab-accordion-child > .esab__body{border-top:1px solid #f3a77f;padding:16px;background:#ffffff;} ","allowAllClose":true} -->
+<div class="wp-block-esab-accordion ACCORDION_ID" data-mode="global" data-close="true"><div class="esab__container"><!-- wp:esab/accordion-child {"uniqueId":"ACCORDION_CHILD_ID","blockStyle":" .ACCORDION_CHILD_ID.wp-block-esab-accordion-child .esab__badge{border-style: solid;} ","heading":"<strong>See all available PLATFORM trigger events in Bit Integrations</strong>","headingTag":"p","collapsedIcon":"esab__circle_plus","expandedIcon":"esab__circle_minus"} -->
+<div class="wp-block-esab-accordion-child"><div class="esab__head" role="button" aria-expanded="false"><div class="esab__heading_txt"><p class="esab__heading_tag"><strong>See all available PLATFORM trigger events in Bit Integrations</strong></p></div><div class="esab__icon"><div class="esab__collapse"> <svg version="1.2" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="m3.5 20.5c-4.7-4.7-4.7-12.3 0-17 4.7-4.7 12.3-4.7 17 0 4.6 4.7 4.6 12.3 0 17-4.7 4.6-12.3 4.6-17 0zm0.9-0.9c4.2 4.2 11 4.2 15.2 0 4.2-4.2 4.2-11 0-15.2-4.2-4.3-11-4.3-15.2 0-4.3 4.2-4.3 11 0 15.2z"></path><path d="m11.4 15.9v-3.3h-3.3c-0.3 0-0.6-0.3-0.6-0.6 0-0.4 0.3-0.6 0.6-0.6h3.3v-3.3c0-0.3 0.3-0.6 0.6-0.6 0.3 0 0.6 0.3 0.6 0.6v3.3h3.3c0.3 0 0.6 0.2 0.6 0.6q0 0.2-0.2 0.4-0.2 0.2-0.4 0.2h-3.3v3.3q0 0.2-0.2 0.4-0.2 0.2-0.4 0.2c-0.4 0-0.6-0.3-0.6-0.6z"></path></svg> </div><div class="esab__expand"> <svg version="1.2" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="m12 24c-6.6 0-12-5.4-12-12 0-6.6 5.4-12 12-12 6.6 0 12 5.4 12 12 0 6.6-5.4 12-12 12zm10.6-12c0-5.9-4.7-10.6-10.6-10.6-5.9 0-10.6 4.7-10.6 10.6 0 5.9 4.7 10.6 10.6 10.6 5.9 0 10.6-4.7 10.6-10.6z"></path><path d="m5.6 11.3h12.8v1.4h-12.8z"></path></svg> </div></div></div><div class="esab__body">H4 CATEGORY HEADINGS + EVENT TABLES GO HERE</div></div>
+<!-- /wp:esab/accordion-child --></div></div>
+<!-- /wp:esab/accordion -->
+
+<!-- note / important callout -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"className":"note_col"} -->
+<div class="wp-block-column note_col"><!-- wp:freeform -->
+<p><img class="alignnone size-full wp-image-4353" src="https://bitapps.pro/wp-content/uploads/2023/06/info-icon.png" alt="note-icon-bit-apps" width="24" height="24" />  <strong>Note</strong></p>
+<!-- /wp:freeform -->
+
+<!-- wp:paragraph -->
+<p>NOTE TEXT</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- placeholder screenshot -->
+<!-- wp:image {"align":"center","size":"large"} -->
+<figure class="wp-block-image aligncenter size-large">
+  <img src="PLACEHOLDER_SOURCE_URL" alt="TODO: screenshot of SLOT_DESCRIPTION"/>
+  <figcaption>Replace with a real screenshot: SLOT_DESCRIPTION</figcaption>
+</figure>
+<!-- /wp:image -->
+
+<!-- real fixed image -->
+<!-- wp:image {"id":MEDIA_ID,"align":"center","sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image aligncenter size-large">
+  <img src="SOURCE_URL" alt="ALT" class="wp-image-MEDIA_ID"/>
+</figure>
+<!-- /wp:image -->
+```
+
+## Placeholder image slots
+
+Every `{{PLACEHOLDER:<slot>}}` resolves from
+`DOC_PLACEHOLDER_ATTACHMENT_POST_ID`; only alt text and caption change. Alt text
+must follow the site's style — a plain sentence describing the shot. The alts
+below are the ones used in the canonical Bit CRM doc, with the platform
+substituted.
+
+| Slot | Alt text |
+|---|---|
+| `select-trigger-app` | `search and select <Platform> as a trigger` |
+| `select-trigger-event` | `choose specific <Platform> trigger events` |
+| `fetch-button` | `Click on <Platform> fetch button` |
+| `waiting-for-submission` | `Waiting for form submission` |
+| `fetched-fields` | `Bit Integrations successfully fetched the test submission` |
+| `webhook-url` | `Copy the Bit Integrations webhook URL for <Platform>` (webhook branch only) |
+
+Fixed images:
+
+| Slot | `.env` source | Alt |
+|---|---|---|
+| `create-integration` | `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID` | `Create-Integration` |
+
+Resolve every attachment post ID through
+`GET $DOC_SITE_URL/wp-json/wp/v2/media/<id>` and embed its `source_url` and
+attachment ID. Do not upload or cache these images.
+
+## Media and EazyDocs API
+
+Read credentials, the parent section post ID, and media IDs from `.env`:
+`DOC_SITE_URL`, `DOC_SITE_USERNAME`, `DOC_SITE_PASSWORD`,
+`DOC_TRIGGER_PARENT_POST_ID`, `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`,
+`DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`. `DOC_SITE_PASSWORD` must be a
+WordPress Application Password. Never print it.
+
+Resolve an attachment:
+
+```bash
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  "$DOC_SITE_URL/wp-json/wp/v2/media/<media-id>"
+```
+
+Create the draft child. The title here must already have `&`/`#`/`+` replaced
+with `ezd_ampersand`/`ezd_hash`/`ezd_plus`:
+
+```bash
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  -H "Content-Type: application/json" \
+  -d '{"parent_id":<DOC_TRIGGER_PARENT_POST_ID>,"title":"<encoded title>","post_status":"draft"}' \
+  "$DOC_SITE_URL/wp-json/eazydocs/v1/docs-builder/create-child"
+```
+
+Set content. The Gutenberg HTML is full of quotes, so never inline it in
+`-d '...'`; write the JSON body to a temp file in the scratchpad directory
+(title/slug **raw** here, not token-encoded) and send that:
+
+```bash
+# build body.json first, e.g. with jq --rawfile for the content field
+curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
+  -H "Content-Type: application/json" \
+  --data @body.json \
+  "$DOC_SITE_URL/wp-json/wp/v2/docs/<id>"
+```
+
+`body.json`:
+
+```json
+{
+  "slug": "<platform-slug>-integration",
+  "title": "<Platform> Integration as a Trigger",
+  "ezd_doc_secondary_title": "<Platform>",
+  "content": "<gutenberg html beginning with the h1>"
+}
+```
+
+`ezd_doc_secondary_title` is exposed as a REST **field** on the `docs` post type
+(via `register_rest_field`) by a site-specific code snippet — EazyDocs Pro's own
+build does not register it; the `docs` CPT's `supports` array omits
+`custom-fields`, so a plain `register_post_meta()` would silently fail to surface
+at all. Send it as a **top-level** key, not nested under `meta`; a
+`{"meta": {...}}` payload is silently ignored. Confirm the field exists first by
+inspecting the authenticated `OPTIONS` schema for `wp/v2/docs/<id>`.
+
+After the update, fetch the doc with `context=edit` and verify:
+
+- `title.raw` equals the full public title.
+- `slug` equals the intended slug (not `...-2`).
+- `ezd_doc_secondary_title` equals `<Platform>`.
+
+Only when the field is absent from the `OPTIONS` schema, fall back to manual
+entry: return the draft edit link and ask the user to open it, find the EazyDocs
+Pro **Secondary Title** panel, set its **Title** field to `<Platform>`, and save
+the draft. Wait for confirmation, then verify the sidebar label before reporting
+completion.

--- a/.claude/skills/create-trigger-doc/reference.md
+++ b/.claude/skills/create-trigger-doc/reference.md
@@ -152,13 +152,23 @@ sidebar.
 **WordPress/EazyDocs post title:**
 
 ```text
-<Platform> Integration as a Trigger
+<Platform> Integration
 ```
 
-Examples: `Bit CRM Integration as a Trigger`,
-`NextCRM Integration as a Trigger`. Use the exact `name` value from
-`backend/Core/Util/AllTriggersName.php`. Use singular `Integration`, never
-`Integrations`.
+Examples: `Bit CRM Integration`, `NextCRM Integration`. Use the exact `name`
+value from `backend/Core/Util/AllTriggersName.php`. Use singular `Integration`,
+never `Integrations`.
+
+> **Never write the phrase `as a Trigger` anywhere in a trigger doc** — not in
+> the post title, an H1, an H2/H3 heading, image alt text or body prose. Trigger
+> docs own the plain `<Platform> Integration` title and the plain
+> `<platform-slug>-integration` slug; the doc type is already clear from the
+> `Trigger` section it lives in. Where a heading has to name the wizard screen,
+> use the real screen name instead: `Search and Select <Platform> on the Trigger
+> Screen`, because `Please select a Trigger` is what the reader actually sees.
+> Grep the finished Gutenberg HTML for `as (a|the|your) trigger`
+> case-insensitively before the approval preview; the count must be `0`.
+> Action docs are unaffected — they keep `<Platform> Integration as an Action`.
 
 > **Note:** The post title must be SEO-friendly and user-friendly. Include the
 > exact platform name, use natural language, and avoid keyword stuffing, vague
@@ -184,8 +194,8 @@ Examples: `bit-crm-integration`, `nextcrm-integration`,
 `fluentplayer-integration`. Always singular `-integration`, and **no**
 `-as-a-trigger` suffix — the trigger doc owns the short, canonical slug.
 
-The post title still reads `<Platform> Integration as a Trigger`; only the slug
-drops the suffix. Action docs keep the full
+The post title and the slug now agree: `<Platform> Integration` and
+`<platform-slug>-integration`. Action docs keep the full
 `<platform-slug>-integration-as-an-action`, so the two doc types never collide.
 
 | Doc type | Slug |
@@ -222,21 +232,21 @@ Step headings use **Title Case** and no leading zero: `Step 1: Click the Fetch
 Button`, not `Step 01: click the fetch button`.
 
 ```text
-<h1>  <Platform> Integration as a Trigger
+<h1>  <Platform> Integration
       <TL;DR paragraph>
       <3 overview paragraphs>
 <h2>  How the <Platform> Trigger Works
 <h2>  Before You Start
-<h2>  How to Set Up <Platform> Integration as a Trigger in Bit Integrations
+<h2>  How to Set Up the <Platform> Integration in Bit Integrations
       <one paragraph: how many steps and which one needs care>
 <h3>    Step 1: Open Bit Integrations and Click Create Integration
-<h3>    Step 2: Search and Select <Platform> as the Trigger
+<h3>    Step 2: Search and Select <Platform> on the Trigger Screen
 <h3>    Step 3: Choose Your Trigger Event
 <h3>    Step 4: Click the Fetch Button
 <h3>    Step 5: Create a Test Record Within the 3 Minute Window
 <h3>    Step 6: Review the Fetched Data and Click Set Action
       <closing paragraph>
-<h2>  Explore <N> Useful <Platform> Integration as a Trigger Use Cases
+<h2>  Explore <N> Useful <Platform> Integration Use Cases
 ```
 
 Do not add an Action walkthrough, a step summary, or a roadmap list.
@@ -248,8 +258,8 @@ paragraphs. It is the block a reader in a hurry acts on, and the block answer
 engines quote, so it carries the whole procedure in compressed form.
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fff5ef"},"spacing":{"padding":{"top":"18px","right":"20px","bottom":"18px","left":"20px"},"margin":{"bottom":"28px"}},"border":{"radius":"3px","left":{"color":"#f3a77f","width":"4px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#f3a77f;border-left-width:4px;background-color:#fff5ef;margin-bottom:28px;padding:18px 20px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration as a trigger, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;prerequisites&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
+<!-- wp:group {"className":"bi-tldr","layout":{"type":"constrained"}} -->
+<div class="wp-block-group bi-tldr"><!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> To set up the &lt;Platform&gt; integration in Bit Integrations, &lt;shortest accurate path in one sentence, naming the real button and event labels&gt;. You need &lt;prerequisites&gt;. The whole setup takes about &lt;N&gt; minutes.</p><!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 ```
 
@@ -374,10 +384,10 @@ From your WordPress dashboard, go to Bit Integrations. On the welcome screen or 
 Then the fixed screenshot `{{SHOT:create-integration}}` using
 `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`.
 
-### Step 2: Search and Select `<Platform>` as the Trigger
+### Step 2: Search and Select `<Platform>` on the Trigger Screen
 
 ```text
-You will land on the trigger selection screen. Type <Platform> into the search box and click the <Platform> card when it appears.
+You land on the Please select a Trigger screen. Type <Platform> into the Search Trigger... box and click the <Platform> card when it appears.
 ```
 
 The real screen heading is `Please select a Trigger`
@@ -472,7 +482,7 @@ Skip the accordion entirely when the trigger has no fixed event set.
 
 ## Use-case section
 
-`<h2>` `Explore <N> Useful <Platform> Integration as a Trigger Use Cases`, then:
+`<h2>` `Explore <N> Useful <Platform> Integration Use Cases`, then:
 
 ```text
 Here are <N> automations that solve real problems for small teams. Each one uses the same <N>-step setup described above, with a different action app at the end.
@@ -607,19 +617,17 @@ These <N> are only the starting point. Bit Integrations connects <Platform> to 3
 ## Block vocabulary — visual hierarchy
 
 Three styled block types, and no others. Every doc uses the same three so the
-Users Guide reads as one system. All colours are **inline**, because EazyDocs has
-no theme CSS behind custom classes; inline styles on `wp:group` survive the REST
-sanitiser, custom class names do not.
+Users Guide reads as one system.
 
 The rule that governs all three: **how loud a block may be depends on how many
 times the reader meets it.** A block seen once can shout. A block that repeats
 five times must whisper, or it becomes noise and drowns the one that matters.
 
-| Tier | Block | Times per doc | Left bar | Fill | Border |
-|---|---|---|---|---|---|
-| 1 | TL;DR | exactly 1 | `#f3a77f` 4px | `#fff5ef` | — |
-| 2 | Warning | 2-4 | `#d97757` 4px | `#fdf3f0` | — |
-| 3 | Use-case card | 4-5 | — | `#fdfcfb` | 1px `#e8e2dd` |
+| Tier | Block | Class | Times per doc |
+|---|---|---|---|
+| 1 | TL;DR | `bi-tldr` | exactly 1 |
+| 2 | Warning | `bi-warn` | 2-4 |
+| 3 | Use-case card | `bi-card` | 4-5 |
 
 Same shape, different colour, is what makes the vocabulary learnable. Do not
 invent a fourth style, and do not box anything outside these three.
@@ -628,72 +636,93 @@ invent a fourth style, and do not box anything outside these three.
 accordion. Tables already carry their own structure and steps are already
 delimited by their H3s, so boxing them tips the page into a wall of panels.
 
-### Inner margins — required on every styled block
+### Colours live in one `<style>` block, never in inline styles
 
-A styled group sets its own padding, and the theme also puts a bottom margin on
-the last `<p>` or `<ul>` inside it. The two stack, so the block renders with a
-visibly larger gap at the bottom than the top. Most themes use
-`margin: 0 0 1em`, which is why the defect shows up only at the bottom.
+The docs site has a **dark mode** (an `ezd_dark_switch` toggle that puts
+`body_dark` on `<body>`). An inline `style="background:#fff5ef"` cannot say
+"…and something else in dark mode", so a block styled inline becomes a glaring
+light slab on a near-black page — or, worse, keeps the theme's light text and
+turns invisible.
 
-Zero the inner margins explicitly — the group's padding is then the only
-spacing, and the box is symmetric:
+Inline styles also lose outright to the theme's `!important` rules:
 
-| Group contains | Fix |
-|---|---|
-| one paragraph (TL;DR, warning) | `margin-top:0;margin-bottom:0` on that paragraph |
-| several blocks (use-case card) | `margin-top:0` on the first block, `margin-bottom:0` on the last |
-
-Set it in **both** places, the block comment attribute and the inline `style`,
-or the editor and the front end disagree:
-
-```html
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0">TEXT</p><!-- /wp:paragraph -->
-
-<!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li>ITEM</li></ul><!-- /wp:list -->
+```css
+body.body_dark.single-docs #post p       { color:#eaeaea !important }   /* (1,2,2) */
+.doc-middle-content tr:nth-child(2n)     { color:#000    !important }   /* (0,2,1) */
+.body_dark.single-docs .wp-block-esab-accordion-child > .esab__active.esab__body
+                                         { background:#494949 !important } /* (0,5,0) */
 ```
 
-Never fix this by shrinking the group's bottom padding — that depends on the
-theme's font size and breaks the moment the theme changes.
+So: **put the class on the block, and put every colour in one `wp:html`
+`<style>` block at the top of the content.** A `<style>` block survives the REST
+write intact, `body_dark` selectors included, which is the only way to express a
+real dark variant. Verify with `context=edit` after writing.
 
-### Tier 2 — warning callout
-
-For the conditions that cost the reader a failed run. Place each one **before**
-the action it protects. Quote the exact error string from the helper when there
-is one — a reader who has already hit it will search for that text.
-
-Earns a warning:
-
-- a plan gate, on either side (`Bit Integrations Pro`, the platform's own Pro
-  tier, a third-party API tier)
-- an irreversible write — permanent delete, overwrite, "cannot be undone"
-- a precondition that makes the action fail — a record that must already exist,
-  a field that must already be populated
-
-Does not earn one: anything already obvious from the field table, or a mere
-preference.
+Emit the group with a `className` and **no** `style` attribute:
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fdf3f0"},"spacing":{"padding":{"top":"14px","right":"18px","bottom":"14px","left":"18px"},"margin":{"top":"18px","bottom":"18px"}},"border":{"radius":"3px","left":{"color":"#d97757","width":"4px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-radius:3px;border-left-color:#d97757;border-left-width:4px;background-color:#fdf3f0;margin-top:18px;margin-bottom:18px;padding:14px 18px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0;margin-bottom:0"><strong>LEAD CONDITION.</strong> WHAT HAPPENS AND WHAT TO DO INSTEAD.</p><!-- /wp:paragraph --></div>
+<!-- wp:group {"className":"bi-tldr","layout":{"type":"constrained"}} -->
+<div class="wp-block-group bi-tldr"><!-- wp:paragraph --><p class="wp-block-paragraph"><strong>TL;DR:</strong> …</p><!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 ```
 
-State a gate **once**. If a warning callout covers a requirement, delete the
-duplicate sentences elsewhere — repeating the same fact three times reads as
-padding and pushes the real content down.
+Warnings use `bi-warn`, use-case cards use `bi-card`, with the card's linked
+bold title, rationale paragraph and Trigger/Action list inside. Padding and
+margins come from the stylesheet, so drop the old `margin-top:0`/`margin-bottom:0`
+zeroing attributes — they exist only to patch inline padding.
 
-### Tier 3 — use-case card
+### The stylesheet — paste verbatim as the first block of every doc
 
-Wraps each block in the use-case section: the linked bold title, the rationale
-paragraph, and the Trigger/Action list. Quietest treatment of the three, because
-it repeats.
+Selectors that must beat a theme `!important` rule carry the
+`body.body_dark.single-docs #post` prefix to clear its specificity. Do not
+shorten them.
 
 ```html
-<!-- wp:group {"style":{"color":{"background":"#fdfcfb"},"spacing":{"padding":{"top":"20px","right":"22px","bottom":"20px","left":"22px"},"margin":{"top":"16px","bottom":"16px"}},"border":{"radius":"4px","color":"#e8e2dd","width":"1px"}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-background" style="border-color:#e8e2dd;border-width:1px;border-radius:4px;background-color:#fdfcfb;margin-top:16px;margin-bottom:16px;padding:20px 22px"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0"}}}} --><p class="wp-block-paragraph" style="margin-top:0">LINKED BOLD TITLE</p><!-- /wp:paragraph --><!-- wp:paragraph --><p class="wp-block-paragraph">RATIONALE</p><!-- /wp:paragraph --><!-- wp:list {"style":{"spacing":{"margin":{"bottom":"0"}}}} --><ul class="wp-block-list" style="margin-bottom:0"><li><strong>Trigger:</strong> …</li><li><strong>Action:</strong> …</li></ul><!-- /wp:list --></div>
-<!-- /wp:group -->
+<!-- wp:html --><style>
+/* ---- Bit Integrations doc blocks ---- */
+.bi-tldr{background:#fff5ef;color:#2b2119;border-left:4px solid #f3a77f;border-radius:3px;padding:18px 20px;margin:0 0 28px}
+.bi-warn{background:#fdf3f0;color:#2b2119;border-left:4px solid #d97757;border-radius:3px;padding:14px 18px;margin:18px 0}
+.bi-card{background:#fdfcfb;color:#2b2119;border:1px solid #e8e2dd;border-radius:4px;padding:20px 22px;margin:16px 0}
+.single-docs #post .bi-tldr p,.single-docs #post .bi-warn p,.single-docs #post .bi-card p,.single-docs #post .bi-card li{color:inherit!important}
+.single-docs #post .bi-card a{color:#6b21a8!important}
+body.body_dark .bi-tldr{background:#241c17;color:#f1e6dd;border-left-color:#f3a77f}
+body.body_dark .bi-warn{background:#2b1e19;color:#f7e0d6;border-left-color:#d97757}
+body.body_dark .bi-card{background:#1b1c21;color:#e7e2dd;border-color:#34363d}
+body.body_dark.single-docs #post .bi-tldr p,body.body_dark.single-docs #post .bi-warn p,body.body_dark.single-docs #post .bi-card p,body.body_dark.single-docs #post .bi-card li{color:inherit!important}
+body.body_dark.single-docs #post .bi-card a{color:#cbaef7!important}
+/* ---- tables follow the theme; only the hardcoded zebra fill is neutralised ---- */
+#post .wp-block-table table{background:transparent!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table th{background:rgba(127,127,127,.13)!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table td{background:transparent!important;border-color:rgba(127,127,127,.32)!important}
+#post .wp-block-table tbody tr:nth-child(odd){background:transparent!important}
+#post .wp-block-table tbody tr:nth-child(even){background:rgba(127,127,127,.07)!important}
+/* the theme pairs its stripe with a forced black text colour; drop that too */
+#post .wp-block-table tbody tr:nth-child(even),#post .wp-block-table tbody tr:nth-child(even) td,#post .wp-block-table tbody tr:nth-child(even) th{color:inherit!important}
+/* the theme's brand link colour drops to 2:1 on the dark page */
+body.body_dark.single-docs #post p a,body.body_dark.single-docs #post li a{color:#cbaef7!important}
+/* ---- accordion ----
+   The head keeps the esab plugin's own purple: it ships that with !important at
+   a specificity we would have to fight, it is readable in both modes, and every
+   other doc on the site already looks that way. Only the body is ours. */
+.wp-block-esab-accordion .wp-block-esab-accordion-child{border:1px solid rgba(127,127,127,.3);border-radius:3px;overflow:hidden}
+body.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__body,body.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__active.esab__body{background:#fbfaf9!important;border-top:1px solid rgba(127,127,127,.28);padding:16px}
+body.body_dark.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__body,body.body_dark.single-docs .wp-block-esab-accordion .wp-block-esab-accordion-child>.esab__active.esab__body{background:#1b1c21!important;border-top-color:rgba(127,127,127,.22)}
+</style><!-- /wp:html -->
 ```
 
+Why each table rule exists: the theme stripes even rows `#f7f7f7` **and** forces
+`color:#000` on them. Neutralising only the background leaves black text on a
+dark row; neutralising only the colour leaves a light row on a dark page. Both
+have to go, and the replacement stripe is a translucent grey so it reads
+correctly in either mode.
+
+### The accordion `blockStyle` attribute is decorative — never rely on it
+
+The esab accordion's `blockStyle` attribute is **not applied on the front end**
+of this site. A doc that puts its colours there ships unstyled: the head renders
+the plugin's default purple and the body takes the theme's dark `#494949`. Keep
+whatever `blockStyle` the snippet already carries, but never put a colour you
+depend on in it — those rules belong in the `<style>` block above.
 ### The existing note callout
 
 The site's `note_col` block still exists and renders an info icon above the
@@ -772,7 +801,7 @@ substituted.
 
 | Slot | Alt text |
 |---|---|
-| `select-trigger-app` | `search and select <Platform> as a trigger` |
+| `select-trigger-app` | `search and select <Platform> on the Please select a Trigger screen` |
 | `select-trigger-event` | `choose specific <Platform> trigger events` |
 | `fetch-button` | `Click on <Platform> fetch button` |
 | `waiting-for-submission` | `Waiting for form submission` |
@@ -831,7 +860,7 @@ curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
 ```json
 {
   "slug": "<platform-slug>-integration",
-  "title": "<Platform> Integration as a Trigger",
+  "title": "<Platform> Integration",
   "ezd_doc_secondary_title": "<Platform>",
   "content": "<gutenberg html beginning with the h1>"
 }

--- a/.claude/skills/create-trigger-doc/reference.md
+++ b/.claude/skills/create-trigger-doc/reference.md
@@ -5,10 +5,10 @@ Load only after the platform and its trigger `type` are known.
 **Canonical published example:**
 `https://bit-integrations.com/wp-docs/trigger/bit-crm-integration-as-a-trigger/`
 (post ID `124651`). When this reference and that doc disagree, the published doc
-wins — fetch it with
+wins - fetch it with
 `curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs/124651?_fields=content"` and match it.
 
-## Writing standards — SEO and readability
+## Writing standards - SEO and readability
 
 These apply to the **entire document**, not just the title. Check them before
 sending the doc for approval.
@@ -32,7 +32,7 @@ sending the doc for approval.
 **Structure**
 
 - Exactly one H1. Never skip heading levels (H1 → H2 → H3 → H4).
-- Every heading is descriptive and front-loaded with the meaningful word — a
+- Every heading is descriptive and front-loaded with the meaningful word - a
   reader scanning only the headings must be able to follow the whole setup.
 - Answer-first: the first one or two sentences under **every** heading fully
   answer that heading. No warm-up, no "in this section we will look at".
@@ -41,7 +41,7 @@ sending the doc for approval.
 - This page is a **task doc**, not a tutorial or a concept page. It does not
   teach what a webhook or a CRM is. Link out to the doc that does.
 
-**Accuracy — hard rules**
+**Accuracy - hard rules**
 
 Documentation errors cost more than SEO errors.
 
@@ -65,9 +65,9 @@ Documentation errors cost more than SEO errors.
   `[VERIFY: exact wording of the API key screen in <Platform>]` flag in the
   draft **and** a line in the approval preview. Never quietly guess.
   Every `[VERIFY: …]` must be resolved and removed before the draft is
-  published — grep the content for `[VERIFY` as a release gate.
+  published - grep the content for `[VERIFY` as a release gate.
 
-**Extractability — how LLMs and answer engines read the page**
+**Extractability - how LLMs and answer engines read the page**
 
 - Every paragraph must survive being lifted out on its own. No orphan pronouns:
   "This mapping lets you…", not "This lets you…".
@@ -85,7 +85,7 @@ Documentation errors cost more than SEO errors.
 
 **Readability**
 
-- Second person, active voice, present tense. Short sentences — average under
+- Second person, active voice, present tense. Short sentences - average under
   20 words, split anything longer.
 - Paragraphs of three to four sentences at most.
 - Around a grade-8 reading level. Expand an acronym on first use.
@@ -106,12 +106,25 @@ Documentation errors cost more than SEO errors.
 - Never promise a ranking, an AI citation or a rich snippet anywhere in the doc
   or in the report about it.
 
+**Punctuation**
+
+- **Never use an em dash (`-`) anywhere in the doc.** Not in prose, headings,
+  table cells, image alt text, the TL;DR, the meta description or a use-case
+  card. Rewrite instead: split the sentence at a full stop, use a colon before
+  an explanation, use a comma for an aside, or use brackets. Two short sentences
+  almost always beat one dash-joined sentence.
+- The en dash (`-`) is out too. Use a plain hyphen for ranges and compounds
+  (`150-160 characters`, `two-part model`).
+- Grep the finished Gutenberg HTML for the em dash and the en dash before the
+  approval preview; both counts must be `0`, including inside the `<style>`
+  block and any CSS comment that ships with it.
+
 **Links and images**
 
 - Two to four internal links to related docs on `bit-integrations.com`: the
   matching action doc for the same platform when it exists, the conditional
   logic doc, and one or two related trigger docs. Anchor text must be
-  descriptive and carry the destination's own keyword — never `click here`,
+  descriptive and carry the destination's own keyword - never `click here`,
   never a bare URL.
 - Link once per destination per page. A second identical link adds nothing.
 - Link back to prerequisites and concepts, forward to the logical next task.
@@ -126,7 +139,7 @@ Documentation errors cost more than SEO errors.
   when the platform is visible; when the screenshot is a generic Bit Integrations
   screen that does not contain it, describe that screen honestly and add the
   platform only as context ("…, the first step of the `<Platform>` trigger
-  setup"). Never write an alt claiming a screenshot shows something it does not —
+  setup"). Never write an alt claiming a screenshot shows something it does not -
   including a state that is not captured, such as "with a plugin chosen" on a
   shot where nothing is selected.
 - Open every screenshot before writing its alt or placing it. The file name and
@@ -159,7 +172,7 @@ Examples: `Bit CRM Integration`, `NextCRM Integration`. Use the exact `name`
 value from `backend/Core/Util/AllTriggersName.php`. Use singular `Integration`,
 never `Integrations`.
 
-> **Never write the phrase `as a Trigger` anywhere in a trigger doc** — not in
+> **Never write the phrase `as a Trigger` anywhere in a trigger doc**: not in
 > the post title, an H1, an H2/H3 heading, image alt text or body prose. Trigger
 > docs own the plain `<Platform> Integration` title and the plain
 > `<platform-slug>-integration` slug; the doc type is already clear from the
@@ -168,7 +181,7 @@ never `Integrations`.
 > Screen`, because `Please select a Trigger` is what the reader actually sees.
 > Grep the finished Gutenberg HTML for `as (a|the|your) trigger`
 > case-insensitively before the approval preview; the count must be `0`.
-> Action docs are unaffected — they keep `<Platform> Integration as an Action`.
+> Action docs are unaffected - they keep `<Platform> Integration as an Action`.
 
 > **Note:** The post title must be SEO-friendly and user-friendly. Include the
 > exact platform name, use natural language, and avoid keyword stuffing, vague
@@ -192,7 +205,7 @@ to `post_title` only when empty.
 
 Examples: `bit-crm-integration`, `nextcrm-integration`,
 `fluentplayer-integration`. Always singular `-integration`, and **no**
-`-as-a-trigger` suffix — the trigger doc owns the short, canonical slug.
+`-as-a-trigger` suffix - the trigger doc owns the short, canonical slug.
 
 The post title and the slug now agree: `<Platform> Integration` and
 `<platform-slug>-integration`. Action docs keep the full
@@ -213,23 +226,26 @@ new one:
 curl -s "$DOC_SITE_URL/wp-json/wp/v2/docs?parent=$DOC_TRIGGER_PARENT_POST_ID&search=<Platform>&_fields=id,slug,title"
 ```
 
-Also check the exact slug is free (`wp/v2/docs?slug=...`) — WordPress silently
+Also check the exact slug is free (`wp/v2/docs?slug=...`) - WordPress silently
 renames a duplicate to `...-2`. If it is taken, stop and confirm with the user.
 
 When posting the title to the EazyDocs `create-child` endpoint, replace `&` with
 `ezd_ampersand`, `#` with `ezd_hash`, and `+` with `ezd_plus`; that endpoint
 decodes them back via `decode_special_chars`. Send the title/slug **raw**
-(unencoded) to the core `wp/v2/docs/<id>` endpoint — it does not decode these
+(unencoded) to the core `wp/v2/docs/<id>` endpoint - it does not decode these
 tokens, so an encoded title would be stored literally.
 
 ## Document structure
 
-The content opens with an H1 that repeats the post title — published trigger docs
+The content opens with an H1 that repeats the post title - published trigger docs
 on this site keep the H1 inside the content, so match that. H2 for sections, H3
 for steps, H4 for event categories inside the accordion.
 
-Step headings use **Title Case** and no leading zero: `Step 1: Click the Fetch
-Button`, not `Step 01: click the fetch button`.
+Step headings use **Title Case** and a **two-digit number**, zero-padded:
+`Step 01: Click the Fetch Button`, not `Step 01: Click the Fetch Button` and not `Step 01: click the fetch button`.
+Pad every step from `01` to `09`; `10` and beyond are already two digits.
+Numbered sub-steps inside a step follow the same rule (`01.`, `02.`), and
+prose that refers to a range uses the padded form too (`Steps 01-03`).
 
 ```text
 <h1>  <Platform> Integration
@@ -239,19 +255,19 @@ Button`, not `Step 01: click the fetch button`.
 <h2>  Before You Start
 <h2>  How to Set Up the <Platform> Integration in Bit Integrations
       <one paragraph: how many steps and which one needs care>
-<h3>    Step 1: Open Bit Integrations and Click Create Integration
-<h3>    Step 2: Search and Select <Platform> on the Trigger Screen
-<h3>    Step 3: Choose Your Trigger Event
-<h3>    Step 4: Click the Fetch Button
-<h3>    Step 5: Create a Test Record Within the 3 Minute Window
-<h3>    Step 6: Review the Fetched Data and Click Set Action
+<h3>    Step 01: Open Bit Integrations and Click Create Integration
+<h3>    Step 02: Search and Select <Platform> on the Trigger Screen
+<h3>    Step 03: Choose Your Trigger Event
+<h3>    Step 04: Click the Fetch Button
+<h3>    Step 05: Create a Test Record Within the 3 Minute Window
+<h3>    Step 06: Review the Fetched Data and Click Set Action
       <closing paragraph>
 <h2>  Explore <N> Useful <Platform> Integration Use Cases
 ```
 
 Do not add an Action walkthrough, a step summary, or a roadmap list.
 
-### TL;DR — mandatory, always first
+### TL;DR - mandatory, always first
 
 One paragraph, placed immediately after the H1 and before the overview
 paragraphs. It is the block a reader in a hurry acts on, and the block answer
@@ -267,10 +283,10 @@ Rules:
 
 - Two to four sentences. Never more.
 - It must work **alone**. An experienced reader acts on the TL;DR and never
-  scrolls further, so a path that only makes sense after reading Step 3 has
+  scrolls further, so a path that only makes sense after reading Step 03 has
   failed.
 - Name the real UI labels and a real event label, bolded, under the same
-  accuracy rules as the rest of the page — **Create Integration**, **Fetch**,
+  accuracy rules as the rest of the page - **Create Integration**, **Fetch**,
   **Set Action**, and one event copied verbatim from the controller.
 - Contain the primary keyword naturally. This is inside the first 100 words, so
   it satisfies that placement requirement.
@@ -282,19 +298,19 @@ Rules:
 - Adjust the path per branch: a `webhook` trigger's TL;DR names copying the
   webhook URL, not clicking Fetch.
 
-### Overview — 3 paragraphs
+### Overview - 3 paragraphs
 
 ```text
 <Paragraph 1: what the platform stores or does, in plain language, and one line saying Bit Integrations is what makes that data travel.>
 
-<Paragraph 2: once the two are connected, anything that happens in <Platform> can automatically start an action somewhere else — then name 4-5 concrete destinations the platform's own payload can actually feed, e.g. a WhatsApp message, a new row in Google Sheets, a Slack alert, a subscriber added to your email list.>
+<Paragraph 2: once the two are connected, anything that happens in <Platform> can automatically start an action somewhere else - then name 4-5 concrete destinations the platform's own payload can actually feed, e.g. a WhatsApp message, a new row in Google Sheets, a Slack alert, a subscriber added to your email list.>
 
 This guide walks through the full <Platform> trigger setup in Bit Integrations, lists every supported trigger event, and shows <N> practical automations you can build in a few minutes.
 ```
 
 Human-written, simple, customer-friendly. No stiff marketing copy, no developer
 jargon. Every destination named in paragraph 2 must exist in the `integs` array
-in `frontend/src/components/Flow/New/SelectAction.jsx` — never invent an action
+in `frontend/src/components/Flow/New/SelectAction.jsx`: never invent an action
 integration.
 
 Paragraph 2 is subject to **Use-case realism** below. Each destination must be
@@ -339,7 +355,7 @@ platform requires.
 The whole setup takes <N> steps. Follow them in order, because the fetch step in the middle depends on a live test record.
 ```
 
-Adjust for the branch — a `form`-listing trigger has no fetch step, so say what
+Adjust for the branch - a `form`-listing trigger has no fetch step, so say what
 its fiddly step is instead.
 
 ### Branch table
@@ -348,11 +364,11 @@ The step sequence depends on `info()['type']`:
 
 | `type` | UI component | Step sequence |
 |---|---|---|
-| `custom_form_submission` | `CustomFormSubmission.jsx` | The 6-step Fetch flow below — this is the canonical shape |
-| `form` with a fixed event list (controller `getAll()` returns constant-backed titles) | `FormPlugin.jsx` | Steps 1-3 identical; there is no Fetch button, so Steps 4-6 collapse into `Step 4: Select Your Options and Click Next` |
-| `form` listing the site's own forms/posts | `FormPlugin.jsx` | Steps 1-2 identical; `Step 3: Choose Your Form` replaces the event step and there is no accordion; then `Step 4: Click Next` |
-| `webhook` | `Webhook.jsx` | Steps 1-2 identical; `Step 3: Copy the Webhook URL`, `Step 4: Paste the URL into <Platform>`, `Step 5: Send One Test Payload`, `Step 6: Review the Fetched Data and Click Set Action` |
-| `action_hook` / `custom_trigger` | `ActionHook.jsx` / `CustomTrigger.jsx` | Steps 1-2 identical; `Step 3: Register the Hook Name`, `Step 4: Fire the Hook Once`, `Step 5: Review the Fetched Data and Click Set Action` |
+| `custom_form_submission` | `CustomFormSubmission.jsx` | The 6-step Fetch flow below - this is the canonical shape |
+| `form` with a fixed event list (controller `getAll()` returns constant-backed titles) | `FormPlugin.jsx` | Steps 01-03 identical; there is no Fetch button, so Steps 04-06 collapse into `Step 04: Select Your Options and Click Next` |
+| `form` listing the site's own forms/posts | `FormPlugin.jsx` | Steps 01-02 identical; `Step 03: Choose Your Form` replaces the event step and there is no accordion; then `Step 04: Click Next` |
+| `webhook` | `Webhook.jsx` | Steps 01-02 identical; `Step 03: Copy the Webhook URL`, `Step 04: Paste the URL into <Platform>`, `Step 05: Send One Test Payload`, `Step 06: Review the Fetched Data and Click Set Action` |
+| `action_hook` / `custom_trigger` | `ActionHook.jsx` / `CustomTrigger.jsx` | Steps 01-02 identical; `Step 03: Register the Hook Name`, `Step 04: Fire the Hook Once`, `Step 05: Review the Fetched Data and Click Set Action` |
 
 ### Step craft rules
 
@@ -360,7 +376,7 @@ These apply to every `Step N:` heading, in every branch.
 
 - **One action per step.** If the body needs "and then", it is two steps.
 - Open each step with an imperative verb the reader can act on: Click, Open,
-  Select, Enter, Enable, Copy. Never "Configure as needed" — a step you cannot
+  Select, Enter, Enable, Copy. Never "Configure as needed" - a step you cannot
   describe concretely is not a step.
 - Name the exact UI element and its exact label, in the real path form:
   **Bit Integrations → Create Integration**.
@@ -371,11 +387,11 @@ These apply to every `Step N:` heading, in every branch.
 - When a step branches, give each branch its own labelled sentence or bullet
   rather than nested "if … otherwise" prose.
 - The closing paragraph must contain a concrete success check the reader can
-  see — which screen to open and what should appear there — not just "you are
+  see - which screen to open and what should appear there - not just "you are
   done".
 - Keep the count realistic. Past about ten steps, group them into phases.
 
-### Step 1: Open Bit Integrations and Click Create Integration
+### Step 01: Open Bit Integrations and Click Create Integration
 
 ```text
 From your WordPress dashboard, go to Bit Integrations. On the welcome screen or the integrations list, click the Create Integration button. This opens a trigger selection page.
@@ -384,7 +400,7 @@ From your WordPress dashboard, go to Bit Integrations. On the welcome screen or 
 Then the fixed screenshot `{{SHOT:create-integration}}` using
 `DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID`.
 
-### Step 2: Search and Select `<Platform>` on the Trigger Screen
+### Step 02: Search and Select `<Platform>` on the Trigger Screen
 
 ```text
 You land on the Please select a Trigger screen. Type <Platform> into the Search Trigger... box and click the <Platform> card when it appears.
@@ -395,13 +411,13 @@ The real screen heading is `Please select a Trigger`
 
 Then `{{PLACEHOLDER:select-trigger-app}}`.
 
-### Step 3: Choose Your Trigger Event
+### Step 03: Choose Your Trigger Event
 
 ```text
 Open the Select a Form/Task Name dropdown and pick the trigger event you want to listen for. The dropdown holds every supported <Platform> event, so pick the one that matches the exact moment you want your automation to start.
 ```
 
-`Select a Form/Task Name` is the real dropdown label — do not reword it.
+`Select a Form/Task Name` is the real dropdown label - do not reword it.
 
 Then the **event accordion** (below), then:
 
@@ -417,7 +433,7 @@ Use three to five events, labels copied verbatim from the controller.
 
 Then `{{PLACEHOLDER:select-trigger-event}}`.
 
-### Step 4: Click the Fetch Button
+### Step 04: Click the Fetch Button
 
 ```text
 After you select an event, a Fetch button appears. Click it. Bit Integrations now starts listening for a real record so it can learn the field structure of that event.
@@ -425,21 +441,21 @@ After you select an event, a Fetch button appears. Click it. Bit Integrations no
 
 Then `{{PLACEHOLDER:fetch-button}}`.
 
-### Step 5: Create a Test Record Within the 3 Minute Window
+### Step 05: Create a Test Record Within the 3 Minute Window
 
 ```text
-The Fetch button changes to a spinning "Waiting for form submission" state with a three-minute countdown. During that window, go and perform the exact action you selected in Step 3.
+The Fetch button changes to a spinning "Waiting for form submission" state with a three-minute countdown. During that window, go and perform the exact action you selected in Step 03.
 
 The test record must match the trigger event you chose. If you selected <Event A>, <do X in the platform>. If you selected <Event B>, <do Y>. If you selected <Event C>, <do Z>.
 ```
 
 `Waiting for form submission...` is the real button state
 (`CustomFormSubmission.jsx`). If the countdown ends before the test lands,
-nothing is broken — say so, and say to click Fetch again.
+nothing is broken - say so, and say to click Fetch again.
 
 Then `{{PLACEHOLDER:waiting-for-submission}}`.
 
-### Step 6: Review the Fetched Data and Click Set Action
+### Step 06: Review the Fetched Data and Click Set Action
 
 ```text
 As soon as the test record is captured, the button turns into "Fetched" and a field table appears. Every field from that record is listed with its detected data type, and the sample values from your test record are shown alongside. Check that the fields you care about are there, for example <3-4 real field labels>, and adjust any data type from its dropdown if the detected type is not what you want.
@@ -474,7 +490,7 @@ Example row from the canonical doc:
 > was typed in manually, imported, or captured by a connected form.
 
 Never reword an event label. If a controller constant has no matching entry in
-the list endpoint, it is dead or deprecated — leave it out and mention it in the
+the list endpoint, it is dead or deprecated - leave it out and mention it in the
 approval preview. When the trigger has fewer than about eight events, one
 ungrouped table without H4s is fine.
 
@@ -488,7 +504,7 @@ Skip the accordion entirely when the trigger has no fixed event set.
 Here are <N> automations that solve real problems for small teams. Each one uses the same <N>-step setup described above, with a different action app at the end.
 ```
 
-Then one block per use case — the title is a **bold linked paragraph**, not a
+Then one block per use case - the title is a **bold linked paragraph**, not a
 heading:
 
 ```text
@@ -513,7 +529,7 @@ Use four or five use cases. Every destination app must exist in the `integs`
 array in `SelectAction.jsx`; every trigger event must exist in the controller's
 list endpoint.
 
-### Use-case realism — hard rules
+### Use-case realism - hard rules
 
 Every use case must be an automation a real site owner would actually build.
 This is the section most likely to go wrong, because a generic pairing reads
@@ -528,7 +544,7 @@ choosing a destination app. The payload decides what is possible:
 | an email address and a name | an email marketing or CRM app |
 | an order or payment record | a spreadsheet, accounting or CRM app |
 | a support or form message | a chat app, helpdesk or notification channel |
-| only an internal record ID | another app on the same site, or nothing — pick a different event |
+| only an internal record ID | another app on the same site, or nothing - pick a different event |
 
 If the destination needs a field the trigger never sends, the use case is
 invalid. Never assume a payload contains an email, a phone number or a total.
@@ -542,14 +558,14 @@ action app does with the data and nothing more. Recurring traps:
   notification.
 
 **Banned opener.** Do not write "when someone submits a form, places an order, or
-registers as a user" — or any variant that lists generic events and staples them
+registers as a user" - or any variant that lists generic events and staples them
 to whatever destinations exist. Name one concrete actor doing one concrete
 thing: a customer, a student, a subscriber, a team member.
 
 **State the manual work removed.** One clause naming what the reader stops doing
 by hand is what makes a use case useful rather than decorative.
 
-**Name the real gotcha** when the pairing has one — a Pro requirement, a field
+**Name the real gotcha** when the pairing has one - a Pro requirement, a field
 the reader must map manually, a plan tier on the destination app's side.
 
 Worked example of the failure this rule exists to prevent:
@@ -571,7 +587,7 @@ https://bit-integrations.com/triggers/<platform-connect-slug>/connect/<destinati
 Example: `https://bit-integrations.com/triggers/fluent-player/connect/google-sheets/`
 
 Both slugs belong to the marketing site and are **not derived** from anything in
-this repo — not the doc slug, not the `AllTriggersName.php` key, not the
+this repo - not the doc slug, not the `AllTriggersName.php` key, not the
 `integs` `type` value. Observed mismatches:
 
 | Source value | Connect slug |
@@ -588,7 +604,7 @@ this repo — not the doc slug, not the `AllTriggersName.php` key, not the
 
 Verify **positively**. A live connect page's title matches
 `<Destination> Integration with <Platform> - Automate Your Tasks`. Do not test
-for a specific 404 string — the site serves at least two of them
+for a specific 404 string - the site serves at least two of them
 (`Page not found` and `Page Not Found - Bit Integrations`), so a match against
 one of those will pass a dead URL through.
 
@@ -599,7 +615,7 @@ curl -sL "https://bit-integrations.com/triggers/<platform>/connect/<app>/" \
 ```
 
 The pairing always lives under `/triggers/…/connect/…`, whichever side the doc
-is about. There is no `/actions/<app>/connect/<x>/` route — that path soft-404s.
+is about. There is no `/actions/<app>/connect/<x>/` route - that path soft-404s.
 `/actions/<app>/` and `/integrations/<app>/` also resolve but serve an unrelated
 page, so never link to either.
 
@@ -614,7 +630,7 @@ Close with one wrap-up paragraph:
 These <N> are only the starting point. Bit Integrations connects <Platform> to 378+ apps, including <6-8 real platform names>. The setup process is the same every time.
 ```
 
-## Block vocabulary — visual hierarchy
+## Block vocabulary - visual hierarchy
 
 Three styled block types, and no others. Every doc uses the same three so the
 Users Guide reads as one system.
@@ -641,7 +657,7 @@ delimited by their H3s, so boxing them tips the page into a wall of panels.
 The docs site has a **dark mode** (an `ezd_dark_switch` toggle that puts
 `body_dark` on `<body>`). An inline `style="background:#fff5ef"` cannot say
 "…and something else in dark mode", so a block styled inline becomes a glaring
-light slab on a near-black page — or, worse, keeps the theme's light text and
+light slab on a near-black page - or, worse, keeps the theme's light text and
 turns invisible.
 
 Inline styles also lose outright to the theme's `!important` rules:
@@ -669,9 +685,9 @@ Emit the group with a `className` and **no** `style` attribute:
 Warnings use `bi-warn`, use-case cards use `bi-card`, with the card's linked
 bold title, rationale paragraph and Trigger/Action list inside. Padding and
 margins come from the stylesheet, so drop the old `margin-top:0`/`margin-bottom:0`
-zeroing attributes — they exist only to patch inline padding.
+zeroing attributes - they exist only to patch inline padding.
 
-### The stylesheet — paste verbatim as the first block of every doc
+### The stylesheet - paste verbatim as the first block of every doc
 
 Selectors that must beat a theme `!important` rule carry the
 `body.body_dark.single-docs #post` prefix to clear its specificity. Do not
@@ -716,18 +732,18 @@ dark row; neutralising only the colour leaves a light row on a dark page. Both
 have to go, and the replacement stripe is a translucent grey so it reads
 correctly in either mode.
 
-### The accordion `blockStyle` attribute is decorative — never rely on it
+### The accordion `blockStyle` attribute is decorative - never rely on it
 
 The esab accordion's `blockStyle` attribute is **not applied on the front end**
 of this site. A doc that puts its colours there ships unstyled: the head renders
 the plugin's default purple and the body takes the theme's dark `#494949`. Keep
 whatever `blockStyle` the snippet already carries, but never put a colour you
-depend on in it — those rules belong in the `<style>` block above.
+depend on in it - those rules belong in the `<style>` block above.
 ### The existing note callout
 
 The site's `note_col` block still exists and renders an info icon above the
 literal word **Note**. Use it only for genuine asides. Never use it for the
-TL;DR — it would label the primary path as an aside — and never for a warning,
+TL;DR - it would label the primary path as an aside - and never for a warning,
 which needs its own colour.
 
 After setting content, verify the blocks survived by refetching with
@@ -795,7 +811,7 @@ names.
 
 Every `{{PLACEHOLDER:<slot>}}` resolves from
 `DOC_PLACEHOLDER_ATTACHMENT_POST_ID`; only alt text and caption change. Alt text
-must follow the site's style — a plain sentence describing the shot. The alts
+must follow the site's style - a plain sentence describing the shot. The alts
 below are the ones used in the canonical Bit CRM doc, with the platform
 substituted.
 
@@ -867,7 +883,7 @@ curl -s -u "$DOC_SITE_USERNAME:$DOC_SITE_PASSWORD" \
 ```
 
 `ezd_doc_secondary_title` is exposed as a REST **field** on the `docs` post type
-(via `register_rest_field`) by a site-specific code snippet — EazyDocs Pro's own
+(via `register_rest_field`) by a site-specific code snippet - EazyDocs Pro's own
 build does not register it; the `docs` CPT's `supports` array omits
 `custom-fields`, so a plain `register_post_meta()` would silently fail to surface
 at all. Send it as a **top-level** key, not nested under `meta`; a

--- a/.env.example
+++ b/.env.example
@@ -12,16 +12,16 @@ DOC_SITE_PASSWORD=
 
 # EazyDocs parent section post IDs (children of the Bit Integrations doc root, 2638)
 # Trigger section: https://bit-integrations.com/wp-docs/trigger/
-DOC_TRIGGER_PARENT_POST_ID=2652
+DOC_TRIGGER_PARENT_POST_ID=
 # Actions section: https://bit-integrations.com/wp-docs/actions/
-DOC_ACTION_PARENT_POST_ID=2654
+DOC_ACTION_PARENT_POST_ID=
 
 # Attachment post ID reused for every {{PLACEHOLDER:<slot>}} screenshot slot.
 # Upload one "screenshot pending" image to the docs site and put its media ID here.
 DOC_PLACEHOLDER_ATTACHMENT_POST_ID=
 
 # Shared "Create Integration" screenshot used as Step 1 of every trigger doc.
-DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID=124264
+DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID=
 
 # Shared "Please select a Trigger" screenshot (the trigger plugin grid) used as
 # Step 1 of every action doc, after the Create Integration shot.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Documentation publishing settings used by the /create-trigger-doc and
+# /create-action-doc skills (.claude/skills/). Copy this file to .env and fill
+# in the values. .env is gitignored — never commit real credentials.
+
+# Docs site
+DOC_SITE_URL=https://bit-integrations.com
+DOC_SITE_USERNAME=
+# WordPress Application Password (Users > Profile > Application Passwords),
+# NOT the wp-admin login password. The user must be an Administrator or hold
+# the EazyDocs edit_docs/publish_docs capabilities.
+DOC_SITE_PASSWORD=
+
+# EazyDocs parent section post IDs (children of the Bit Integrations doc root, 2638)
+# Trigger section: https://bit-integrations.com/wp-docs/trigger/
+DOC_TRIGGER_PARENT_POST_ID=2652
+# Actions section: https://bit-integrations.com/wp-docs/actions/
+DOC_ACTION_PARENT_POST_ID=2654
+
+# Attachment post ID reused for every {{PLACEHOLDER:<slot>}} screenshot slot.
+# Upload one "screenshot pending" image to the docs site and put its media ID here.
+DOC_PLACEHOLDER_ATTACHMENT_POST_ID=
+
+# Shared "Create Integration" screenshot used as Step 1 of every trigger doc.
+DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID=124264

--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ DOC_PLACEHOLDER_ATTACHMENT_POST_ID=
 
 # Shared "Create Integration" screenshot used as Step 1 of every trigger doc.
 DOC_CREATE_INTEGRATION_ATTACHMENT_POST_ID=124264
+
+# Shared "Please select a Trigger" screenshot (the trigger plugin grid) used as
+# Step 1 of every action doc, after the Create Integration shot.
+DOC_TRIGGER_LIST_ATTACHMENT_POST_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ node_modules
 .php-cs-fixer.cache
 build/
 .port
+.env
+# Claude Code machine-local state
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,28 @@ Save/update calls use `saveActionConf()` from `IntegrationHelpers.js` → `bitsF
 **Pro plugin:**
 - Free plugin detects Pro via `class_exists('BitApps\\IntegrationsPro\\...')`
 - `Flow::isActionExists()` checks free namespace first, then two Pro namespaces
-- `backend/Triggers/AllTriggersName.php` lists Pro triggers with `isPro: true` for upsell UI
+- `backend/Core/Util/AllTriggersName.php` lists Pro triggers with `isPro: true` for upsell UI
 
 **i18n:**
 - JS uses `__()` from `frontend/src/Utils/i18nwrap.js` (checks `APP_CONFIG.translations` first, falls back to `@wordpress/i18n`)
+
+## User Guide Docs
+
+Two repo skills generate draft Users Guide docs on `bit-integrations.com` (EazyDocs):
+
+| Skill | Invocation | Publishes under |
+|---|---|---|
+| `.claude/skills/create-trigger-doc/` | `/create-trigger-doc <Platform>` | `/wp-docs/trigger/` (parent post `2652`) |
+| `.claude/skills/create-action-doc/` | `/create-action-doc <Platform>` | `/wp-docs/actions/` (parent post `2654`) |
+
+Both mine the free + Pro plugin source for their content: triggers from
+`backend/Core/Util/AllTriggersName.php` + `{Name}Controller::info()` + `Hooks.php`;
+actions from `SelectAction.jsx`'s `integs` array + `AllIntegrations/{Name}/staticData.js`
++ `{Name}Authorization.jsx`. Both create **drafts** with placeholder screenshots and
+require approval on the public title before publishing.
+
+Credentials and media IDs come from `.env` (gitignored) — see `.env.example`.
+
+Doc slug/title conventions (titles keep the full phrase; only the trigger slug is short):
+- Trigger: `<Platform> Integration as a Trigger` / `<platform-slug>-integration`
+- Action: `<Platform> Integration as an Action` / `<platform-slug>-integration-as-an-action`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,12 @@ require approval on the public title before publishing.
 
 Credentials and media IDs come from `.env` (gitignored) — see `.env.example`.
 
-Doc slug/title conventions (titles keep the full phrase; only the trigger slug is short):
-- Trigger: `<Platform> Integration as a Trigger` / `<platform-slug>-integration`
+Doc slug/title conventions:
+- Trigger: `<Platform> Integration` / `<platform-slug>-integration` — the phrase
+  `as a Trigger` must not appear anywhere in a trigger doc
 - Action: `<Platform> Integration as an Action` / `<platform-slug>-integration-as-an-action`
+
+Both doc types style their TL;DR, warning and use-case blocks with the shared
+`bi-tldr` / `bi-warn` / `bi-card` classes plus one `<style>` block at the top of
+the content — never inline colours, which cannot express the site's dark mode.
+See the **Block vocabulary** section of either skill's `reference.md`.


### PR DESCRIPTION
## Description

Adds two repo skills, `/create-trigger-doc` and `/create-action-doc`, that generate draft Users Guide pages on `bit-integrations.com` by mining this plugin's own source instead of being written by hand. Each skill reads the integration's controller, hooks and React UI, drafts a full Gutenberg page, publishes it as an EazyDocs draft under the right parent section, and sets the Rank Math SEO fields. This PR is tooling and documentation only; no plugin runtime code changes.

## Motivation & Context

Users Guide pages were written by hand for each integration, which made them slow to produce and easy to get wrong. Event labels, field labels and button text drifted from what the code actually emits, and use cases often described automations the integration cannot perform.

Both skills solve that by treating the source as the only allowed input: event labels come from `staticData.js` and the trigger controller's task list, button text from the React components, and behaviour from `RecordApiHelper.php` or the Pro helper. Anything that cannot be traced to a file becomes an explicit `[VERIFY: ...]` flag that blocks publishing.

## Related Links: (if applicable)

<!-- Notion issue, feature request, or discussion link -->

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] ⚡ Improvement
- [ ] 🔄 Code refactor

## Key Changes

### **Doc generation skills**

- **Added** `.claude/skills/create-trigger-doc/` covering all five trigger `type` branches (`custom_form_submission`, both `form` shapes, `webhook`, `action_hook` / `custom_trigger`), each with its own step sequence.
- **Added** `.claude/skills/create-action-doc/`, which derives the connection step from the integration's real auth type (`wp_plugin_check`, `oauth2`, `oauth1`, `api_key`, `bearer_token`, `basic_auth`, `custom`) rather than assuming one flow.
- **Added** an approval gate to both: nothing is created until the title, the traced labels and a six-group self-check are reviewed.

### **Accuracy rules**

- **Added** a source-of-truth order, so labels and behaviour are copied character for character and never paraphrased or borrowed from a similar integration.
- **Added** use-case realism rules that derive each pairing from the event's actual field signature, with worked examples of the failure they prevent (adding a record to a container is not granting access to it; writing a row to an email table is not sending an email).
- **Added** `[VERIFY: ...]` flags for anything unverifiable from source, plus a grep gate that must return zero before publishing.
- **Added** a ban on `(PRO)` markers in reference tables, and on the phrase `as a Trigger` anywhere in a trigger doc.

### **Styling and dark mode**

- **Added** a shared block vocabulary (`bi-tldr`, `bi-warn`, `bi-card`) whose colours live in one `<style>` block rather than inline styles, because inline styles cannot express a dark variant and lose to the theme's `!important` rules.
- **Added** the specific theme rules a doc has to out-specify, with their specificities, so the next author does not rediscover them: the forced paragraph colour, the zebra stripe and its paired black text, and the accordion body pinned to a light grey.
- **Added** a note that the esab accordion's `blockStyle` attribute is not applied on the site's front end, so no colour may depend on it.

### **Writing standards**

- **Added** SEO and extractability rules: keyword placement, answer-first headings, no orphan pronouns, no hedging, and honest image alt text that describes what is actually in the frame.
- **Added** a punctuation rule banning the em dash and en dash anywhere in a generated doc, including the shared `<style>` block.
- **Updated** step headings to a zero-padded two-digit form (`Step 01:`, `Step 02:`).

### **Repo configuration**

- **Added** `.env.example` documenting the docs-site credentials and the shared screenshot media IDs the skills read.
- **Updated** `.gitignore` to exclude `.env` and Claude Code machine-local state.
- **Updated** `CLAUDE.md` with a User Guide Docs section covering both skills, their parent sections and the slug and title conventions.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [x] Documentation updated if needed
- [ ] README updated if needed

**Notes on the unchecked items:** there is no test runner in this repo, and these files are Markdown instructions with no executable surface to test. `readme.txt` is untouched on purpose, see the Changelog note below.

## Changelog

No `readme.txt` entry. This PR ships developer tooling and repo documentation only; there is no user-facing plugin change to announce. The Users Guide pages the skills produce are published to `bit-integrations.com` separately and are not part of the plugin release.
